### PR TITLE
Add ALSA capture source and bridge recipes for M1 usability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,15 @@ Implementation language is **C** (per CONTRIBUTING.md and the M1 sketch in `desi
 
 A two-binary system plus a future MCU firmware:
 
-- **`talker/`** — Linux userspace. Reads audio from a source (test tone, WAV, ALSA capture), constructs AoE frames, emits them via `AF_PACKET` at 8000 pps aligned to USB microframes. Depends on libc; optionally libasound2 for live capture.
+- **`talker/`** — Linux userspace. Reads audio from a source (test tone, WAV, ALSA capture), constructs AoE frames, emits them via `AF_PACKET` at 8000 pps aligned to USB microframes. Depends on libc and libasound2 (the latter for the capture source).
 - **`receiver/`** — Linux userspace on Raspberry Pi (Tier 1) or a PTP-capable SBC (Tier 2). Reads AoE frames from `AF_PACKET`, writes samples to an ALSA PCM device backed by `snd_usb_audio`. M1 target is ~100 lines of C. Depends on libasound2.
 - **MCU receiver** (Tier 3, from M7) — bare-metal firmware for NXP MIMXRT1170-EVKB. Hand-rolled USB host UAC2 stack; not present in early milestones.
 
 The core architectural commitment (see `design.md` §"Architecture overview" and Appendix B): the receiver is a **USB host** driving a USB DAC (Topology B). Do **not** reintroduce gadget mode (`f_uac2`, UAC2 device emulation) into the primary path — it is deliberately deferred to post-M9 per Appendix C.
+
+### Music sources are bridged, not native
+
+From M1 onward, AOEther does NOT implement RAAT (Roon), UPnP MediaRenderer, AirPlay, or Spotify Connect natively. These ecosystems are reached by running the appropriate existing daemon (RoonBridge, gmrender-resurrect / rygel, shairport-sync, librespot) on the talker box, having it write to one half of a `snd-aloop` kernel loopback, and running the AOEther talker with `--source alsa --capture hw:Loopback,1,N` on the other half. Recipes live in `docs/recipe-*.md`. This pattern is deliberate — it covers every mainstream Linux music source at effectively zero code cost on our side and inherits Mode C's DAC-clock propagation all the way upstream (snd-aloop's shared ring transmits back-pressure to the source daemon's ALSA write side). Do not add native protocol implementations for these ecosystems without an explicit design-discussion issue that explains why the bridge pattern no longer suffices.
 
 ### Wire format invariants
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AOEther is an open-source system for transporting multichannel PCM and DSD audio over a network into any USB DAC — from a $20 USB headphone dongle to a $10,000 audiophile DAC — with minimal processing on the receiver side. A small program on a Raspberry Pi (or a Linux SBC, or an MCU) copies samples from Ethernet into the DAC's UAC2 input. No sample-rate conversion. No resampling. No DSP. Just bytes from the network to the DAC.
 
-> **Status:** M1 implementation in progress. Design is at [v1.3](docs/design.md). M1 (stereo PCM, RPi + USB DAC, Mode C rate feedback, no PTP) targets its first working build in ~2 weekends of effort.
+> **Status:** M1 implementation in progress. Design is at [v1.3](docs/design.md). M1 — stereo PCM, RPi + USB DAC, Mode C rate feedback, real music sources (Roon / UPnP / system audio via the `snd-aloop` bridge pattern), no PTP — targets first working build in ~3 weekends of effort.
 
 ## What it does
 
@@ -67,7 +67,7 @@ You should hear a clean 1 kHz tone.
 
 | Milestone | Status | Description |
 |-----------|--------|-------------|
-| M1 | In progress | Stereo PCM, RPi + USB DAC, Mode C rate feedback, no PTP |
+| M1 | In progress | Stereo PCM, RPi + USB DAC, Mode C rate feedback, Roon/UPnP/system-audio bridges, no PTP |
 | M2 | Planned | Multichannel PCM (5.1, 7.1, 7.1.4) |
 | M3 | Planned | Tier 2 hardware (Linux SBC), hardware PTP |
 | M4 | Planned | IP/UDP transport (WiFi and routed networks) |
@@ -88,6 +88,17 @@ See [`docs/design.md`](docs/design.md) for the detailed milestone plan and archi
 | 3 | NXP MIMXRT1170 MCU | $200 eval, sub-$50 BOM | Embedded product-grade streamers |
 
 All three run the same protocol.
+
+## How to play music through it
+
+AOEther doesn't implement Roon, UPnP, or AirPlay natively — it bridges them via the kernel's ALSA loopback. Any program that can play to ALSA on Linux becomes a valid AOEther source. Pick the recipe that matches your setup:
+
+- [`docs/quickstart.md`](docs/quickstart.md) — 30-minute bring-up, test-tone smoke test, pointers to the recipes below
+- [`docs/recipe-roon.md`](docs/recipe-roon.md) — Roon (via RoonBridge)
+- [`docs/recipe-upnp.md`](docs/recipe-upnp.md) — UPnP / DLNA controllers (via gmrender-resurrect)
+- [`docs/recipe-capture.md`](docs/recipe-capture.md) — desktop audio (browser, Tidal/Spotify apps, etc.) via PipeWire
+
+The same talker and receiver binaries run under every recipe; only the source daemon changes. AirPlay (shairport-sync) and Spotify Connect (librespot) plug in with the same pattern.
 
 ## Documentation
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -315,13 +315,17 @@ Underruns substitute silence (rather than blocking). Overruns drop oldest slot. 
 
 ## Milestone plan
 
-### M1 — RPi + USB DAC, stereo PCM, Mode C feedback, point-to-point, no PTP
+### M1 — RPi + USB DAC, stereo PCM, Mode C feedback, real music sources, no PTP
 
-**Goal:** Prove Topology B end-to-end with the smallest code that actually holds up. Plug a USB DAC into a Raspberry Pi, stream stereo PCM from a Linux talker, hear clean audio indefinitely. Includes the Mode C feedback loop from day one — an M1 without it fails its own 1-hour soak test (see §"Clock architecture" for why).
+**Goal:** Ship an AOEther that's actually usable for listening, not just a test-tone demo. Plug a USB DAC into a Raspberry Pi, stream stereo PCM from a Linux talker whose input is real music — from Roon, a UPnP controller, AirPlay, Spotify, or any application playing through the OS audio stack — and hear clean audio indefinitely. Includes the Mode C feedback loop from day one — an M1 without it fails its own 1-hour soak test (see §"Clock architecture" for why).
 
-**Deliverables:** Working stereo audio with Mode C clock discipline, talker + receiver in one public repo, README with "first audio in 30 minutes" quickstart. Talker ~400 lines of userspace C; receiver ~250 lines.
+**Approach to music sources:** the talker gains an ALSA capture source. Everything else — Roon (via RoonBridge), UPnP (via gmrender-resurrect or rygel), AirPlay (via shairport-sync), Spotify (via librespot), OS audio (via PipeWire/Pulse) — integrates through the kernel's `snd-aloop` module: the external daemon plays to `hw:Loopback,0,N`, the talker captures from `hw:Loopback,1,N`. No per-ecosystem code in AOEther; one recipe per ecosystem in `docs/recipe-*.md`.
 
-**Time estimate:** 2 weekends.
+This also means the DAC clock propagates all the way up to the source daemon for free — see §"Clock architecture". Adaptive daemons (PipeWire, shairport-sync, RoonBridge) adapt glitch-free; naïve daemons (gmrender, librespot) may xrun rarely and self-recover.
+
+**Deliverables:** Working stereo audio with Mode C clock discipline, real music playback via at least one of {Roon, UPnP, system capture}, talker + receiver in one public repo, per-recipe quickstart docs. Talker ~500 lines of userspace C; receiver ~250 lines.
+
+**Time estimate:** 3 weekends.
 
 See the detailed M1 plan below.
 
@@ -474,7 +478,7 @@ Mode C control path (receiver → talker):
 
 ### Talker (`talker/`)
 
-~400 lines of C, no dependencies beyond libc. Shares `packet.{h,c}` with the receiver via `common/`.
+~500 lines of C, depends on libasound2 for the capture source. Shares `packet.{h,c}` with the receiver via `common/`.
 
 ```
 talker/
@@ -483,8 +487,9 @@ talker/
 └── src/
     ├── talker.c              — main loop, timerfd, sockets, sample accumulator, feedback RX
     ├── audio_source.h        — abstract source interface
-    ├── audio_source_test.c   — 1 kHz sine wave
-    └── audio_source_wav.c    — WAV file loop
+    ├── audio_source_test.c   — 1 kHz sine wave (bring-up, diagnostics)
+    ├── audio_source_wav.c    — WAV file loop (bring-up, diagnostics)
+    └── audio_source_alsa.c   — ALSA capture (primary music-source path; see docs/recipe-*.md)
 ```
 
 Additional Mode C responsibilities:
@@ -577,9 +582,11 @@ sudo ./build/receiver --iface eth0 --dac hw:CARD=Dragonfly,DEV=0
 - [ ] Talker compiles on Ubuntu 22.04 / 24.04.
 - [ ] Receiver compiles on Raspberry Pi OS Bookworm.
 - [ ] Mode C feedback loop working: 1-hour soak with bounded buffer fill (test 6) and a positive control via `--no-feedback` (test 7).
+- [ ] ALSA capture source working: talker plays back a real music stream from at least one of {Roon, UPnP MediaRenderer, PipeWire/Pulse system capture} through to the receiver's USB DAC.
 - [ ] `README.md` with BOM, setup, "first audio in 30 minutes" quickstart.
 - [ ] `docs/design.md` (this doc).
 - [ ] `docs/wire-format.md` including §"Control frames".
+- [ ] `docs/recipe-roon.md`, `docs/recipe-upnp.md`, `docs/recipe-capture.md` bridge recipes.
 - [ ] `CONTRIBUTING.md`.
 - [ ] GitHub Actions CI.
 - [ ] Short demo video.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,90 @@
+# AOEther quickstart
+
+Get AOEther playing real music in about 30 minutes.
+
+AOEther is a two-binary system: a **talker** on whatever box has the music, a **receiver** on whatever box has the USB DAC. Music sources are bridged in via the Linux kernel's `snd-aloop` module — any program that can play to ALSA (that is, essentially any program on Linux) becomes a valid AOEther source.
+
+This page is the fastest happy path. For specific source ecosystems see:
+
+- [`recipe-roon.md`](recipe-roon.md) — Roon users
+- [`recipe-upnp.md`](recipe-upnp.md) — UPnP / DLNA controllers (BubbleUPnP, Kazoo, mconnect)
+- [`recipe-capture.md`](recipe-capture.md) — any desktop audio (Tidal, browser tabs, Spotify desktop, CLI players) via PipeWire / PulseAudio
+
+## What you need
+
+- A Raspberry Pi 4 or 5 with Raspberry Pi OS (Bookworm, 64-bit) — this is the **receiver**.
+- Any UAC2-compliant USB DAC plugged into the Pi.
+- A Linux machine on the same wired LAN — this is the **talker**. It's where the music source runs.
+- Cat 6 between them (or a dumb gigabit switch).
+
+## Step 1 — Build both binaries
+
+On the talker box and the Pi:
+
+```sh
+sudo apt install build-essential libasound2-dev
+git clone https://github.com/<your-org>/AOEther.git
+cd AOEther
+make
+```
+
+This produces `talker/build/talker` and `receiver/build/receiver`.
+
+## Step 2 — Smoke-test with a 1 kHz tone
+
+Find the DAC's ALSA name on the Pi:
+
+```sh
+aplay -L | grep -A1 '^hw:'
+# e.g. hw:CARD=Dragonfly,DEV=0
+```
+
+Find the Pi's MAC as seen from its Ethernet port:
+
+```sh
+ip link show eth0 | awk '/ether/ {print $2}'
+```
+
+On the Pi (receiver):
+
+```sh
+sudo ./receiver/build/receiver \
+    --iface eth0 \
+    --dac hw:CARD=Dragonfly,DEV=0
+```
+
+On the talker box:
+
+```sh
+sudo ./talker/build/talker \
+    --iface eno1 \
+    --dest-mac <pi-mac> \
+    --source testtone
+```
+
+You should hear a clean 1 kHz tone through the DAC. If you do, the wire plumbing, Mode C clock feedback, and USB output are all working end to end.
+
+`Ctrl-C` on both sides to stop.
+
+## Step 3 — Pick a music source
+
+The test tone is just a diagnostic. For real music, pick the recipe that matches your setup:
+
+| You use... | Recipe |
+|---|---|
+| Roon (any tier) | [`recipe-roon.md`](recipe-roon.md) |
+| A UPnP / DLNA controller | [`recipe-upnp.md`](recipe-upnp.md) |
+| Desktop audio (browser, Tidal/Spotify desktop apps, AirPlay, Spotify Connect via librespot) | [`recipe-capture.md`](recipe-capture.md) |
+
+All three recipes share the same pattern: they install a daemon on the talker box that outputs to `hw:Loopback,0,N`, and they run `talker --source alsa --capture hw:Loopback,1,N` to pick it up. The talker and receiver commands above stay exactly the same; only the bridge daemon changes.
+
+## Format lock
+
+M1 hardcodes 48 kHz / 2 channels / 24-bit PCM on the wire. Configure every source daemon to output that format. Mismatches fail with a clear error on startup — AOEther never silently resamples. Higher rates, multichannel, and DSD arrive in M2/M6.
+
+## When it doesn't work
+
+- **Receiver starts but no audio**: check the receiver's `rx` counter on shutdown. If it's nonzero, packets arrive but ALSA playback may be misconfigured — verify `aplay -D hw:CARD=...,DEV=0 /usr/share/sounds/alsa/Front_Center.wav` plays a voice cleanly first.
+- **Receiver's `dropped` counter rising fast**: talker and receiver may not be on the same broadcast domain. L2 EtherType `0x88B5` doesn't cross routers or WiFi bridges. M1 is wired point-to-point or via a dumb switch only.
+- **Frequent underruns**: raise the receiver's jitter buffer with `--latency-us 10000`. The default (5000 µs) is tight on busy Pis.
+- **Talker says `Device or resource busy` on the capture device**: some other process is holding it. `fuser -v /dev/snd/*` will tell you who.

--- a/docs/recipe-capture.md
+++ b/docs/recipe-capture.md
@@ -1,0 +1,97 @@
+# Recipe: system audio capture (PipeWire / PulseAudio)
+
+Any desktop application — Tidal app, Spotify desktop, a browser tab playing Bandcamp, `mpv`, `mpd`, `cmus` — can feed AOEther as long as it plays through the OS audio stack. This recipe uses an `snd-aloop` kernel loopback plus PipeWire routing; it's the lowest-friction path because it doesn't require installing any extra daemons.
+
+Target: you're sitting at a Linux machine, you want whatever you play to come out of the remote DAC.
+
+**Clock adaptation**: PipeWire's per-node rate matching is adaptive. It observes the sink's actual hardware rate and paces smoothly. Expect glitch-free playback end to end.
+
+## One-time setup (talker box)
+
+### 1. Load the ALSA loopback kernel module
+
+```sh
+sudo modprobe snd-aloop
+
+# Persist across reboots:
+echo snd-aloop | sudo tee /etc/modules-load.d/snd-aloop.conf
+```
+
+Verify the Loopback card exists:
+
+```sh
+aplay -l | grep Loopback
+# card N: Loopback [Loopback], device 0: Loopback PCM [Loopback PCM]
+# card N: Loopback [Loopback], device 1: Loopback PCM [Loopback PCM]
+```
+
+Note the card number (N). The two "devices" (0 and 1) are the two halves of the loopback — audio written to `hw:Loopback,0,0` appears for capture at `hw:Loopback,1,0`, and vice versa.
+
+### 2. Create a PipeWire sink that targets the loopback playback side
+
+Drop this in `~/.config/pipewire/pipewire.conf.d/99-aoether.conf`:
+
+```
+context.modules = [
+    { name = libpipewire-module-alsa-sink
+        args = {
+            node.name = "aoether"
+            node.description = "AOEther (to remote DAC)"
+            api.alsa.path = "hw:Loopback,0,0"
+            audio.format = "S24_3LE"
+            audio.rate = 48000
+            audio.channels = 2
+        }
+    }
+]
+```
+
+Reload PipeWire:
+
+```sh
+systemctl --user restart pipewire pipewire-pulse
+```
+
+`pw-cli list-objects | grep -A2 aoether` should show the new sink.
+
+## Per-session (talker)
+
+Route the app you want to AOEther. Either set it as default:
+
+```sh
+wpctl set-default $(wpctl status | awk '/aoether/ {print $2}' | tr -d '.')
+```
+
+…or per-stream in `pavucontrol` → Playback tab → redirect the stream to "AOEther (to remote DAC)".
+
+Run the AOEther talker:
+
+```sh
+sudo ./talker/build/talker \
+    --iface eno1 \
+    --dest-mac <pi-mac> \
+    --source alsa \
+    --capture hw:Loopback,1,0
+```
+
+On the Pi (receiver), the usual:
+
+```sh
+sudo ./receiver/build/receiver \
+    --iface eth0 \
+    --dac hw:CARD=Dragonfly,DEV=0
+```
+
+Play something. You should hear it through the remote DAC.
+
+## Caveats
+
+- **Format lock**: the PipeWire sink is pinned to `S24_3LE @ 48000`. Apps running at 44.1 kHz (most non-hi-res streaming) will be resampled by PipeWire on its way into the sink. AOEther itself does no resampling; if you need bit-exact 44.1 kHz you'll need M2's rate negotiation.
+- **Volume knob**: PipeWire's volume control on the aoether sink is digital attenuation before the loopback. For audiophile use keep it at 0 dB and control volume on the DAC. Setting it below 0 dB throws away bits.
+- **Latency**: end-to-end is dominated by PipeWire's scheduling (~10–40 ms typical) plus the AOEther jitter buffer (5 ms default). Fine for music; not for video sync.
+
+## Troubleshooting
+
+- **No sink appears**: `journalctl --user -u pipewire` — look for ALSA sink load errors. A common cause is `snd-aloop` not loaded, or the wrong card number in the config (`hw:Loopback,0,0` assumes it's the first loopback; if another virtual card was registered first, it might be `hw:Loopback_1,0,0`).
+- **Audio plays locally instead of through AOEther**: your default sink wasn't changed. `wpctl status` shows current default; `wpctl set-default ...` to change.
+- **Underruns on the talker**: the source app is producing samples too slowly. Raise PipeWire's `node.quantum` for the aoether sink, or check for CPU contention.

--- a/docs/recipe-roon.md
+++ b/docs/recipe-roon.md
@@ -1,0 +1,76 @@
+# Recipe: Roon
+
+Roon (roonlabs.com) is a widely used music management / streaming platform. Its network audio protocol, RAAT, is closed. AOEther bridges Roon by running **RoonBridge** (Roon's free endpoint binary) on the talker box, configuring it to output to an ALSA loopback, and capturing from the other side of the loopback.
+
+Target: you have a Roon Core running somewhere on your network, and you want a new Roon endpoint that plays through AOEther to a remote USB DAC.
+
+**Clock adaptation**: RoonBridge handles async sinks gracefully — it observes sink hardware rate via ALSA and paces accordingly. Expect glitch-free playback. Roon's own statistics will show clock-related events if any occur.
+
+## One-time setup (talker box)
+
+### 1. Load the ALSA loopback module
+
+```sh
+sudo modprobe snd-aloop
+echo snd-aloop | sudo tee /etc/modules-load.d/snd-aloop.conf
+aplay -l | grep Loopback   # confirm card present
+```
+
+### 2. Install RoonBridge
+
+Download the Linux x64 installer from roonlabs.com and run it:
+
+```sh
+wget https://download.roonlabs.com/builds/RoonBridge_linuxx64.sh
+chmod +x RoonBridge_linuxx64.sh
+sudo ./RoonBridge_linuxx64.sh
+```
+
+It installs a systemd unit and starts on boot. Check it's running:
+
+```sh
+systemctl status roonbridge
+```
+
+(For ARM talkers e.g. an extra Pi, use `RoonBridge_linuxarmv7hf.sh` or `RoonBridge_linuxarmv8.sh` as appropriate.)
+
+### 3. Configure RoonBridge to output to the loopback
+
+In the Roon remote app (on phone or desktop), go to **Settings → Audio**. The talker box will show up as an available zone; under it, several ALSA devices are listed. Find the **Loopback PCM (hw:Loopback,0,0)** entry. Click **Enable**, give it a name like "AOEther Bridge," and under the gear icon set:
+
+- **Device Format**: Custom → 48000 / 24-bit
+- **Resync Delay**: default
+- **Volume Control**: Fixed Volume (let the DAC handle volume)
+- **Enable MQA Core Decoder**: off (M1 doesn't carry MQA)
+
+## Per-session
+
+With Roon configured and the loopback enabled, just run AOEther:
+
+```sh
+# On the talker box
+sudo ./talker/build/talker \
+    --iface eno1 \
+    --dest-mac <pi-mac> \
+    --source alsa \
+    --capture hw:Loopback,1,0
+
+# On the Pi
+sudo ./receiver/build/receiver \
+    --iface eth0 \
+    --dac hw:CARD=Dragonfly,DEV=0
+```
+
+In the Roon app, select "AOEther Bridge" as the playback zone and hit play. Audio flows Roon Core → RoonBridge → snd-aloop → AOEther talker → Ethernet → AOEther receiver → USB DAC.
+
+## Caveats
+
+- **48 kHz cap in M1**: M1 only carries 48 kHz 24-bit stereo. Roon will happily send a 192 kHz track and RoonBridge will downsample to match the configured 48 kHz / 24-bit sink — Roon does this natively with high-quality SRC. Bit-exact high-rate playback awaits M2's rate negotiation.
+- **DSD**: not carried in M1; arrives in M6. RoonBridge will convert DSD to PCM when the sink is PCM-only.
+- **Roon Ready certification**: we're not Roon Ready. We appear as a "Roon Bridge" endpoint, which is fully functional but not the marketed logo. Roon Ready requires NDA and a cert lab pass; that's a post-M8 question if at all.
+
+## Troubleshooting
+
+- **Endpoint not visible in Roon app**: check `systemctl status roonbridge`. Firewall may be blocking RAAT — by default RoonBridge discovery uses multicast + ports 9003/9100-9200 TCP.
+- **Audio drops when skipping tracks**: Roon resyncs at track boundaries. AOEther should recover within ~1 s via the FEEDBACK loop's usual bounded-drift behavior; if drops are persistent, raise `--latency-us` on the receiver.
+- **Clock drift messages in Roon's log**: expected to be rare. If frequent, check `aplay -D hw:Loopback,1,0 -vv` for buffer underruns on the capture side.

--- a/docs/recipe-upnp.md
+++ b/docs/recipe-upnp.md
@@ -1,0 +1,86 @@
+# Recipe: UPnP / DLNA MediaRenderer
+
+UPnP MediaRenderer is the open-standard protocol used by controllers like BubbleUPnP (Android), Kazoo (Linn), mconnect (iOS), Foobar2000, JRiver, and many NAS/DLNA servers. AOEther bridges UPnP by running **gmrender-resurrect** (a minimal, mature MediaRenderer daemon) on the talker box, pointed at an ALSA loopback.
+
+Target: you have a UPnP controller app and a UPnP media server (or just a controller that can push URLs), and you want the rendered output to play through AOEther to a remote USB DAC.
+
+**Clock adaptation**: gmrender-resurrect is a naïve ALSA writer — it doesn't track sink rate and runs at nominal. Under Mode C's DAC-disciplined sink rate, expect the kernel loopback to push back on gmrender occasionally (< 1 event per hour at typical 20 ppm crystal spreads), which gmrender handles as a transient xrun and recovers from. Audible as a very occasional soft tick; fine for casual listening. If you're an audiophile who can't tolerate even that, use the Roon recipe instead — RoonBridge is adaptive.
+
+**License note**: gmrender-resurrect is GPL2-licensed; you install it separately via apt. AOEther itself stays Apache 2.0.
+
+## One-time setup (talker box)
+
+### 1. Load the ALSA loopback module
+
+```sh
+sudo modprobe snd-aloop
+echo snd-aloop | sudo tee /etc/modules-load.d/snd-aloop.conf
+aplay -l | grep Loopback
+```
+
+### 2. Install gmrender-resurrect
+
+On Debian/Ubuntu:
+
+```sh
+sudo apt install gmediarender
+```
+
+(The package name is `gmediarender` in Debian; the binary is `gmediarender`.)
+
+### 3. Configure it to output to the loopback
+
+Edit `/etc/default/gmediarender`:
+
+```
+ENABLED=1
+DAEMON_USER="gmrender"
+UUID="<generate a uuid with `uuidgen`>"
+FRIENDLY_NAME="AOEther UPnP"
+INITIAL_VOLUME_DB=0
+ALSA_DEVICE=hw:Loopback,0,0
+```
+
+Start it:
+
+```sh
+sudo systemctl enable --now gmediarender
+systemctl status gmediarender
+```
+
+Confirm it's announcing itself on the LAN:
+
+```sh
+gssdp-discover -i eno1 -t urn:schemas-upnp-org:device:MediaRenderer:1
+# Should list "AOEther UPnP" with an HTTP description URL.
+```
+
+## Per-session
+
+```sh
+# On the talker box
+sudo ./talker/build/talker \
+    --iface eno1 \
+    --dest-mac <pi-mac> \
+    --source alsa \
+    --capture hw:Loopback,1,0
+
+# On the Pi
+sudo ./receiver/build/receiver \
+    --iface eth0 \
+    --dac hw:CARD=Dragonfly,DEV=0
+```
+
+In your UPnP controller (BubbleUPnP, Kazoo, mconnect, etc.), select **AOEther UPnP** as the playback renderer. Pick tracks from a UPnP MediaServer (MinimServer, minidlna, Plex DLNA) and hit play.
+
+## Caveats
+
+- **Format lock**: gmrender-resurrect does not itself resample. The UPnP controller typically queries the renderer's supported formats and picks one the renderer advertises. With the `ALSA_DEVICE=hw:Loopback,0,0` config above, the kernel loopback will accept a range of formats but we've asked AOEther to capture 48 kHz 24-bit — other rates will fail to play cleanly. For 44.1 kHz sources, configure the controller to transcode or limit the library to 48 kHz content until M2.
+- **Gapless playback**: gmrender-resurrect has known gaps at track boundaries on some versions. Not an AOEther problem; upgrade the package or consider rygel as an alternative.
+- **Album art / now-playing**: the UPnP controller handles all of that; AOEther is just transport.
+
+## Troubleshooting
+
+- **Renderer doesn't appear in controller**: firewall blocking SSDP multicast (port 1900 UDP) or HTTP (default 49494 TCP). Open these or disable the firewall on the talker box for the LAN.
+- **Controller shows renderer but playback fails**: `journalctl -u gmediarender` — a common error is "Audio device busy" (something else has the Loopback card; stop PulseAudio/PipeWire probes with `pulseaudio --kill` or point PipeWire away from Loopback) or "unsupported format" (your source is 44.1 kHz or DSD; see above).
+- **rygel as an alternative**: `apt install rygel` and configure its renderer plugin. Also LGPL. Has richer format support but bigger surface area.

--- a/talker/Makefile
+++ b/talker/Makefile
@@ -1,6 +1,6 @@
 CC      ?= cc
 CFLAGS  ?= -O2 -Wall -Wextra -Wpedantic -std=c11 -D_GNU_SOURCE
-LDLIBS  ?= -lm
+LDLIBS  ?= -lm -lasound
 
 BUILD     := build
 INCLUDES  := -Isrc -I../common
@@ -8,6 +8,7 @@ SRCS      := \
     src/talker.c \
     src/audio_source_test.c \
     src/audio_source_wav.c \
+    src/audio_source_alsa.c \
     ../common/packet.c
 
 .PHONY: all clean

--- a/talker/src/audio_source.h
+++ b/talker/src/audio_source.h
@@ -13,3 +13,4 @@ struct audio_source {
 
 struct audio_source *audio_source_test_open(int channels, int rate, int bytes_per_sample);
 struct audio_source *audio_source_wav_open(const char *path);
+struct audio_source *audio_source_alsa_open(const char *pcm_name, int channels, int rate);

--- a/talker/src/audio_source_alsa.c
+++ b/talker/src/audio_source_alsa.c
@@ -1,0 +1,121 @@
+#include "audio_source.h"
+
+#include <alsa/asoundlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* M1 capture parameters. A generous period size keeps snd-aloop back-pressure
+ * smooth; a generous buffer keeps us tolerant of source-daemon jitter without
+ * shifting drift handling onto us (the DAC clock already propagates through
+ * snd-aloop's ring — see design.md §"Clock architecture"). */
+#define CAPTURE_PERIOD_US   5000      /* 5 ms */
+#define CAPTURE_BUFFER_US   100000    /* 100 ms total */
+
+struct alsa_state {
+    snd_pcm_t *pcm;
+    int channels;
+    int bytes_per_sample;
+};
+
+static int alsa_read(struct audio_source *src, void *buf, size_t frames)
+{
+    struct alsa_state *st = src->opaque;
+    uint8_t *p = buf;
+    size_t remaining = frames;
+    while (remaining > 0) {
+        snd_pcm_sframes_t r = snd_pcm_readi(st->pcm, p, remaining);
+        if (r == -EPIPE || r == -ESTRPIPE) {
+            int rr = snd_pcm_recover(st->pcm, (int)r, 1);
+            if (rr < 0) {
+                fprintf(stderr, "alsa capture: recover: %s\n", snd_strerror(rr));
+                return -1;
+            }
+            continue;
+        }
+        if (r == -EAGAIN) {
+            continue;
+        }
+        if (r < 0) {
+            int rr = snd_pcm_recover(st->pcm, (int)r, 1);
+            if (rr < 0) {
+                fprintf(stderr, "alsa capture: readi: %s\n", snd_strerror((int)r));
+                return -1;
+            }
+            continue;
+        }
+        remaining -= (size_t)r;
+        p += (size_t)r * st->channels * st->bytes_per_sample;
+    }
+    return 0;
+}
+
+static void alsa_close(struct audio_source *src)
+{
+    struct alsa_state *st = src->opaque;
+    if (st) {
+        if (st->pcm) {
+            snd_pcm_drop(st->pcm);
+            snd_pcm_close(st->pcm);
+        }
+        free(st);
+    }
+    free(src);
+}
+
+struct audio_source *audio_source_alsa_open(const char *pcm_name, int channels, int rate)
+{
+    snd_pcm_t *pcm = NULL;
+    int err = snd_pcm_open(&pcm, pcm_name, SND_PCM_STREAM_CAPTURE, 0);
+    if (err < 0) {
+        fprintf(stderr, "alsa capture: open(%s): %s\n", pcm_name, snd_strerror(err));
+        return NULL;
+    }
+
+    err = snd_pcm_set_params(pcm,
+                             SND_PCM_FORMAT_S24_3LE,
+                             SND_PCM_ACCESS_RW_INTERLEAVED,
+                             (unsigned int)channels,
+                             (unsigned int)rate,
+                             0,                    /* disable soft-resample */
+                             CAPTURE_BUFFER_US);
+    if (err < 0) {
+        fprintf(stderr,
+                "alsa capture: set_params on %s (S24_3LE ch=%d rate=%d): %s\n"
+                "  (AOEther M1 locks this format; configure your source daemon to match.)\n",
+                pcm_name, channels, rate, snd_strerror(err));
+        snd_pcm_close(pcm);
+        return NULL;
+    }
+
+    err = snd_pcm_prepare(pcm);
+    if (err < 0) {
+        fprintf(stderr, "alsa capture: prepare: %s\n", snd_strerror(err));
+        snd_pcm_close(pcm);
+        return NULL;
+    }
+
+    struct audio_source *src = calloc(1, sizeof(*src));
+    struct alsa_state *st = calloc(1, sizeof(*st));
+    if (!src || !st) {
+        free(src);
+        free(st);
+        snd_pcm_close(pcm);
+        return NULL;
+    }
+    st->pcm = pcm;
+    st->channels = channels;
+    st->bytes_per_sample = 3;
+
+    src->read = alsa_read;
+    src->close = alsa_close;
+    src->channels = channels;
+    src->rate = rate;
+    src->bytes_per_sample = 3;
+    src->opaque = st;
+
+    fprintf(stderr,
+            "alsa capture: %s opened (S24_3LE ch=%d rate=%d buffer_us=%d)\n",
+            pcm_name, channels, rate, CAPTURE_BUFFER_US);
+    return src;
+}

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -88,8 +88,15 @@ static int64_t ts_diff_ms(struct timespec a, struct timespec b)
 static void usage(const char *prog)
 {
     fprintf(stderr,
-        "usage: %s --iface IF --dest-mac AA:BB:CC:DD:EE:FF\n"
-        "           [--source testtone|wav] [--file PATH]\n",
+        "usage: %s --iface IF --dest-mac AA:BB:CC:DD:EE:FF [options]\n"
+        "  --source testtone|wav|alsa   default: testtone\n"
+        "  --file   PATH                WAV file, required with --source wav\n"
+        "  --capture hw:CARD=...        ALSA capture device, required with --source alsa\n"
+        "\n"
+        "M1 stream is hardcoded 48 kHz / 2ch / s24le-3. Sources must match.\n"
+        "For music playback, point --capture at one half of a snd-aloop pair\n"
+        "and route Roon/UPnP/AirPlay/PipeWire at the other half; see\n"
+        "docs/recipe-*.md.\n",
         prog);
 }
 
@@ -99,22 +106,25 @@ int main(int argc, char **argv)
     const char *dest_s = NULL;
     const char *source = "testtone";
     const char *wav_path = NULL;
+    const char *capture_pcm = NULL;
 
     static const struct option opts[] = {
         { "iface",    required_argument, 0, 'i' },
         { "dest-mac", required_argument, 0, 'd' },
         { "source",   required_argument, 0, 's' },
         { "file",     required_argument, 0, 'f' },
+        { "capture",  required_argument, 0, 'c' },
         { "help",     no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:s:f:h", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:s:f:c:h", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dest_s = optarg; break;
         case 's': source = optarg; break;
         case 'f': wav_path = optarg; break;
+        case 'c': capture_pcm = optarg; break;
         case 'h': usage(argv[0]); return 0;
         default:  usage(argv[0]); return 2;
         }
@@ -139,6 +149,12 @@ int main(int argc, char **argv)
             return 2;
         }
         src = audio_source_wav_open(wav_path);
+    } else if (strcmp(source, "alsa") == 0) {
+        if (!capture_pcm) {
+            fprintf(stderr, "talker: --capture hw:... required with --source alsa\n");
+            return 2;
+        }
+        src = audio_source_alsa_open(capture_pcm, CHANNELS, SAMPLE_RATE_HZ);
     } else {
         fprintf(stderr, "talker: unknown --source %s\n", source);
         return 2;


### PR DESCRIPTION
Make M1 actually usable for listening, not just a test-tone demo. Instead of implementing Roon/UPnP/AirPlay/Spotify natively, the talker gains an ALSA capture source (audio_source_alsa.c) and the recipes document bridging each ecosystem via snd-aloop: RoonBridge, gmrender- resurrect, shairport-sync, librespot, or PipeWire all write to one half of a kernel ALSA loopback, talker captures from the other half.

This inherits Mode C DAC-rate back-pressure for free. snd-aloop shares one ring between playback and capture, so the talker slower-or-faster- than-nominal consumption rate (dictated by DAC via Mode C feedback) propagates directly to the source daemon ALSA write side. Adaptive daemons (PipeWire, shairport-sync, RoonBridge) lock glitch-free end to end; naive daemons (gmrender, librespot) may xrun rarely and recover.

docs/: quickstart.md, recipe-roon.md, recipe-upnp.md, recipe-capture.md. design.md M1 scope tightened to mention real music playback. CLAUDE.md codifies the rule: do not reintroduce native RAAT/UPnP/AirPlay/Spotify protocol code without a design-discussion issue explaining why the bridge pattern no longer suffices. Time estimate 2 -> 3 weekends.