### PR TITLE
Parameterize channels and rate for M2 multichannel + hi-res

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AOEther is an open-source system for transporting multichannel PCM and DSD audio over a network into any USB DAC — from a $20 USB headphone dongle to a $10,000 audiophile DAC — with minimal processing on the receiver side. A small program on a Raspberry Pi (or a Linux SBC, or an MCU) copies samples from Ethernet into the DAC's UAC2 input. No sample-rate conversion. No resampling. No DSP. Just bytes from the network to the DAC.
 
-> **Status:** M1 implementation in progress. Design is at [v1.3](docs/design.md). M1 — stereo PCM, RPi + USB DAC, Mode C rate feedback, real music sources (Roon / UPnP / system audio via the `snd-aloop` bridge pattern), no PTP — targets first working build in ~3 weekends of effort.
+> **Status:** M2 implementation in progress. Design is at [v1.3](docs/design.md). M1 (stereo PCM, Mode C feedback, Roon/UPnP/system-audio bridges) is complete. M2 extends to multichannel and hi-res PCM with per-DAC test coverage.
 
 ## What it does
 
@@ -67,8 +67,8 @@ You should hear a clean 1 kHz tone.
 
 | Milestone | Status | Description |
 |-----------|--------|-------------|
-| M1 | In progress | Stereo PCM, RPi + USB DAC, Mode C rate feedback, Roon/UPnP/system-audio bridges, no PTP |
-| M2 | Planned | Multichannel PCM (5.1, 7.1, 7.1.4) |
+| M1 | Done | Stereo PCM, RPi + USB DAC, Mode C rate feedback, Roon/UPnP/system-audio bridges, no PTP |
+| M2 | In progress | Multichannel PCM (up to 7.1.4 / 16ch), hi-res rates (up to 192 kHz), per-DAC test matrix |
 | M3 | Planned | Tier 2 hardware (Linux SBC), hardware PTP |
 | M4 | Planned | IP/UDP transport (WiFi and routed networks) |
 | M5 | Planned | AVTP AAF wire format for Milan interop |

--- a/docs/dacs.md
+++ b/docs/dacs.md
@@ -1,0 +1,51 @@
+# Tested DAC matrix
+
+Per-DAC test reports covering the AOEther M2 configuration space: channel counts, sample rates, and observed quirks. This file grows as contributors test new hardware. A DAC need not appear here to work — the `snd_usb_audio` kernel stack supports a vast range of UAC2 devices — but this list is the ground truth for "known to work in AOEther."
+
+## How to report
+
+Open a PR adding a row (or a subsection if the DAC has interesting quirks) with:
+
+- DAC model and firmware version (where exposed).
+- Linux kernel version tested on (receiver side).
+- Configurations that worked: `channels × rate × sample format` triples.
+- Any `snd_usb_audio` quirks you had to add or disable (reference the `quirks-table.h` entry if one exists).
+- Any xrun-frequency observations under Mode C soak.
+
+Keep entries terse. One line per confirmed configuration.
+
+## Stereo DACs (confirmed 2-channel through AOEther)
+
+| DAC | Rates confirmed | Notes |
+|-----|-----------------|-------|
+| _(add your DAC here)_ | | |
+
+## Multichannel DACs (6+ channel playback confirmed)
+
+| DAC | Channels × rate | Notes |
+|-----|-----------------|-------|
+| _(add your DAC here)_ | | |
+
+## Known problematic
+
+DACs that appear in `lsusb` as UAC2 but fail in specific AOEther configurations. This is useful to document even when not a fix target for us — contributors trying the same DAC shouldn't hit the wall again.
+
+| DAC | What fails | Workaround (if any) |
+|-----|-----------|---------------------|
+| _(add your DAC here)_ | | |
+
+## Reference test sequence
+
+Before filing a report, run through these to get a complete picture:
+
+1. Receiver and talker both at `--channels 2 --rate 48000`: baseline, must play cleanly.
+2. Receiver and talker at the DAC's max stereo rate (e.g., `--rate 192000`): confirms hi-res stereo path.
+3. If the DAC is multichannel: receiver and talker at the DAC's native channel count × 48 kHz.
+4. 1-hour Mode C soak at whatever config you're reporting; log `fb_sent` on the receiver and `underruns` on both sides.
+5. Negative control: receiver with `--no-feedback`; confirms your feedback loop is doing real work (stream should drift and xrun within minutes).
+
+## What's deliberately out of scope in M2
+
+- 24-bit is the only format; 16-bit and 32-bit widths arrive later. Report hardware failures only for the 24-bit path.
+- DSD support is M6.
+- Multichannel at 384 / 705.6 / 768 kHz is not supported by M2's MTU check (packet splitting is deferred). Very-high-rate tests are for stereo only.

--- a/docs/design.md
+++ b/docs/design.md
@@ -329,15 +329,20 @@ This also means the DAC clock propagates all the way up to the source daemon for
 
 See the detailed M1 plan below.
 
-### M2 — Multichannel PCM
+### M2 — Multichannel PCM, hi-res rates, per-DAC test matrix
 
-**Goal:** Scale to 6ch (5.1), 8ch (7.1), 12ch (7.1.4), and higher using multichannel USB DACs (MiniDSP MCHStreamer, Motu UltraLite, OKTO Research dac8 Stereo, etc.).
+**Goal:** Scale beyond stereo/48 kHz to the rest of the PCM space: 5.1 / 7.1 / 7.1.4 channel counts on multichannel USB DACs (MiniDSP MCHStreamer, Motu UltraLite, OKTO Research dac8, Exasound e38, etc.), and hi-res rates (88.2 / 96 / 176.4 / 192 kHz) for stereo audiophile use. Format lock stays at s24le-3 in M2; additional sample widths arrive later.
 
-**Deliverables:** Talker accepts multichannel source, receiver advertises multichannel capability, verified configurations documented with per-DAC test reports.
+**Deliverables:**
+- `--channels N` and `--rate HZ` on both talker and receiver (matching manually for M2; auto-negotiation arrives in M7 with mDNS-SD / AVDECC).
+- MTU check at talker startup; reject configurations whose worst-case packet exceeds 1500 bytes with a clear message. This caps 12ch at 192 kHz and below; stereo goes all the way to the format lock; 16ch fits at 192 kHz with tight margins.
+- Mode C constants (NOMINAL_SPM, Q16.16 reference, sanity band) derived from the configured rate rather than hardcoded to 48 kHz.
+- `docs/dacs.md` — growing matrix of tested multichannel / hi-res configurations per DAC model.
+- Updated recipe docs covering multichannel sources (Roon 5.1 output, UPnP DLNA multichannel content, PipeWire multichannel routes).
 
-**Key risks:** Multichannel USB DAC support on Linux is uneven; some require quirks or vendor-specific firmware. Document which DACs are known-good.
+**Key risks:** Multichannel USB DAC support on Linux is uneven; some require `snd_usb_audio` quirks or vendor firmware. The test matrix in `docs/dacs.md` is the deliverable that manages this risk — real per-DAC reports rather than vendor-claim parroting.
 
-**Time estimate:** 2 weekends.
+**Time estimate:** 2 weekends + calendar time to accumulate DAC test reports.
 
 ### M3 — Tier 2 hardware, hardware PTP
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -80,7 +80,9 @@ All three recipes share the same pattern: they install a daemon on the talker bo
 
 ## Format lock
 
-M1 hardcodes 48 kHz / 2 channels / 24-bit PCM on the wire. Configure every source daemon to output that format. Mismatches fail with a clear error on startup — AOEther never silently resamples. Higher rates, multichannel, and DSD arrive in M2/M6.
+From M2, the wire accepts any of 44.1 / 48 / 88.2 / 96 / 176.4 / 192 kHz and 1..64 channels at 24-bit PCM, but **the talker and receiver must be started with matching `--channels` and `--rate`**, and the source daemon must produce exactly that format. Mismatches fail with a clear error on startup — AOEther never silently resamples. DSD arrives in M6.
+
+Very-high-rate multichannel combinations (e.g., 12 ch × 384 kHz) exceed the 1500-byte MTU when packed at 8000 pps; the talker rejects such configurations at startup. Typical deployments (stereo up to 192 kHz, 5.1 / 7.1 / 7.1.4 up to 192 kHz, 16 ch at 48 kHz) fit comfortably.
 
 ## When it doesn't work
 

--- a/docs/recipe-capture.md
+++ b/docs/recipe-capture.md
@@ -84,9 +84,21 @@ sudo ./receiver/build/receiver \
 
 Play something. You should hear it through the remote DAC.
 
+## Hi-res stereo and multichannel (M2)
+
+To carry a different rate or channel count, change three things together:
+
+1. The PipeWire sink config in `99-aoether.conf`: `audio.rate = 192000`, `audio.channels = 6`, etc.
+2. The talker: `--rate 192000 --channels 6`.
+3. The receiver: `--rate 192000 --channels 6`.
+
+All three must match. Mismatches fail at startup with a clear error.
+
+For **bit-exact 44.1 kHz** (e.g., Red Book FLAC from a local player), set the sink to `audio.rate = 44100`. PipeWire will then avoid the 48 kHz resampling path for sources that can natively produce 44.1 kHz. Note that some apps (notably browsers) fix their output to 48 kHz regardless; for those you're already resampled upstream and switching the sink to 44.1 kHz just moves where that happens.
+
 ## Caveats
 
-- **Format lock**: the PipeWire sink is pinned to `S24_3LE @ 48000`. Apps running at 44.1 kHz (most non-hi-res streaming) will be resampled by PipeWire on its way into the sink. AOEther itself does no resampling; if you need bit-exact 44.1 kHz you'll need M2's rate negotiation.
+- **Format lock**: the PipeWire sink is pinned at exactly what's in `99-aoether.conf`. Apps at a different rate will be resampled by PipeWire on the way in. AOEther itself does no resampling.
 - **Volume knob**: PipeWire's volume control on the aoether sink is digital attenuation before the loopback. For audiophile use keep it at 0 dB and control volume on the DAC. Setting it below 0 dB throws away bits.
 - **Latency**: end-to-end is dominated by PipeWire's scheduling (~10–40 ms typical) plus the AOEther jitter buffer (5 ms default). Fine for music; not for video sync.
 

--- a/docs/recipe-roon.md
+++ b/docs/recipe-roon.md
@@ -63,11 +63,23 @@ sudo ./receiver/build/receiver \
 
 In the Roon app, select "AOEther Bridge" as the playback zone and hit play. Audio flows Roon Core → RoonBridge → snd-aloop → AOEther talker → Ethernet → AOEther receiver → USB DAC.
 
+## Hi-res stereo and multichannel (M2)
+
+To pass 192 kHz bit-exact, configure both the RoonBridge sink and the AOEther talker+receiver to 192 kHz:
+
+1. In Roon → Settings → Audio → (gear on the Loopback sink), set **Device Format** to **Custom** → `192000` / `24-bit`.
+2. Talker: `sudo ./talker/build/talker --source alsa --capture hw:Loopback,1,0 --channels 2 --rate 192000 ...`
+3. Receiver: `sudo ./receiver/build/receiver --dac hw:CARD=...,DEV=0 --channels 2 --rate 192000 ...`
+
+For multichannel (e.g., 5.1 Atmos bed or surround music), Roon can output multichannel to an ALSA device if the sink advertises it. Configure the Loopback device to match: the kernel's `snd-aloop` is format-agnostic so you just tell Roon to use e.g. `48000 / 24-bit / 6-channel` as the device format, then run talker+receiver with `--channels 6 --rate 48000`.
+
+Roon will auto-downconvert sources that exceed the sink's capability (e.g., a 192 kHz track into a 48 kHz sink does lossy SRC inside Roon). For bit-exact playback run the sink at the highest rate you'll actually send.
+
 ## Caveats
 
-- **48 kHz cap in M1**: M1 only carries 48 kHz 24-bit stereo. Roon will happily send a 192 kHz track and RoonBridge will downsample to match the configured 48 kHz / 24-bit sink — Roon does this natively with high-quality SRC. Bit-exact high-rate playback awaits M2's rate negotiation.
-- **DSD**: not carried in M1; arrives in M6. RoonBridge will convert DSD to PCM when the sink is PCM-only.
-- **Roon Ready certification**: we're not Roon Ready. We appear as a "Roon Bridge" endpoint, which is fully functional but not the marketed logo. Roon Ready requires NDA and a cert lab pass; that's a post-M8 question if at all.
+- **DSD**: not carried until M6. RoonBridge will convert DSD to PCM when the sink is PCM-only.
+- **Roon Ready certification**: we're not Roon Ready. We appear as a "Roon Bridge" endpoint, which is fully functional but not the marketed logo. Roon Ready requires NDA and a cert lab pass; post-M8 question if at all.
+- **MTU**: Roon can theoretically send 12 ch × 384 kHz, but AOEther's M2 rejects that at startup (exceeds 1500-byte MTU). 12 ch × 192 kHz fits; see `docs/design.md` §M2.
 
 ## Troubleshooting
 

--- a/docs/recipe-upnp.md
+++ b/docs/recipe-upnp.md
@@ -73,9 +73,15 @@ sudo ./receiver/build/receiver \
 
 In your UPnP controller (BubbleUPnP, Kazoo, mconnect, etc.), select **AOEther UPnP** as the playback renderer. Pick tracks from a UPnP MediaServer (MinimServer, minidlna, Plex DLNA) and hit play.
 
+## Hi-res stereo and multichannel (M2)
+
+gmrender-resurrect itself is format-agnostic (it forwards whatever the controller sends to the configured ALSA device). To run a different rate / channel count, start the AOEther talker and receiver with matching `--rate` and `--channels` values. The UPnP controller's transcoding settings determine what actually reaches gmrender; configure it to not transcode so source bits pass through to AOEther.
+
+Multichannel UPnP content is less common in the wild than Roon multichannel; if your MediaServer has multichannel FLAC you can play it through with `--channels 6` (or whatever the source has) and an appropriate multichannel DAC on the receiver.
+
 ## Caveats
 
-- **Format lock**: gmrender-resurrect does not itself resample. The UPnP controller typically queries the renderer's supported formats and picks one the renderer advertises. With the `ALSA_DEVICE=hw:Loopback,0,0` config above, the kernel loopback will accept a range of formats but we've asked AOEther to capture 48 kHz 24-bit — other rates will fail to play cleanly. For 44.1 kHz sources, configure the controller to transcode or limit the library to 48 kHz content until M2.
+- **Format lock**: gmrender-resurrect does not itself resample, but the UPnP controller may. Disable transcoding in the controller for bit-exact playback. AOEther rejects any format mismatch at `snd_pcm_set_params()` on the capture side.
 - **Gapless playback**: gmrender-resurrect has known gaps at track boundaries on some versions. Not an AOEther problem; upgrade the package or consider rygel as an alternative.
 - **Album art / now-playing**: the UPnP controller handles all of that; AOEther is just transport.
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -32,8 +32,10 @@ sudo ./build/receiver --iface eth0 \
 Flags:
 
 - `--iface IF`, `--dac hw:...` (required) — as above.
-- `--latency-us N` — ALSA period latency hint (default 5000 µs). The M1 default is generous on purpose; the Mode C loop corrects ppm-scale drift slowly and the buffer also absorbs talker-side `timerfd` jitter.
-- `--no-feedback` — disable FEEDBACK emission. **Diagnostic only** — the positive control for the M1 soak test (design.md §M1 test 7): with feedback off, the stream is expected to drift and xrun within minutes, which is how you confirm Mode C is doing real work when it's on.
+- `--channels N` — channel count (1..64, default 2). Must match the talker.
+- `--rate HZ` — one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Must match the talker.
+- `--latency-us N` — ALSA period latency hint (default 5000 µs). Generous on purpose; the Mode C loop corrects ppm-scale drift slowly and the buffer also absorbs talker-side `timerfd` jitter.
+- `--no-feedback` — disable FEEDBACK emission. **Diagnostic only** — the positive control for the soak test (design.md §M1 test 7): with feedback off, the stream is expected to drift and xrun within minutes, confirming Mode C is doing real work when it's on.
 
 Needs `CAP_NET_RAW` for the raw sockets; easiest path is `sudo`.
 

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -18,18 +18,34 @@
 #include <time.h>
 #include <unistd.h>
 
-/* M1: hardcoded stream format. See docs/design.md §"M1 detailed plan". */
+/* Stream format. Channels and rate are runtime-configured from M2 on; the
+ * sample format is still locked to s24le-3 (other widths arrive later). See
+ * docs/design.md §"M2" for the scope of what's parameterizable. */
 #define STREAM_ID         0x0001
-#define SAMPLE_RATE_HZ    48000
-#define CHANNELS          2
 #define BYTES_PER_SAMPLE  3
 
-/* Generous M1 latency: Mode C corrects a little ppm of drift slowly; the
- * buffer also absorbs timerfd jitter on the talker. See design.md §M1
- * "Known deferred items". */
+/* Defaults match M1's previous hardcoded values. */
+#define DEFAULT_CHANNELS      2
+#define DEFAULT_RATE_HZ       48000
 #define DEFAULT_LATENCY_US    5000
 #define FEEDBACK_PERIOD_MS    20
 #define POLL_TIMEOUT_MS       FEEDBACK_PERIOD_MS
+
+/* Packet RX buffer: largest legal M2 frame is 12 ch × 3 B × 48 samples
+ * (192 kHz microframe) = 1728 B plus 30 B header. 4 KiB is plenty. */
+#define RX_BUF_BYTES     4096
+
+static int rate_supported(int hz)
+{
+    switch (hz) {
+    case 44100: case 48000:
+    case 88200: case 96000:
+    case 176400: case 192000:
+        return 1;
+    default:
+        return 0;
+    }
+}
 
 static volatile sig_atomic_t g_stop;
 
@@ -43,9 +59,12 @@ static void usage(const char *prog)
 {
     fprintf(stderr,
         "usage: %s --iface IF --dac hw:CARD=NAME,DEV=0 [options]\n"
+        "  --channels N     stream channel count (1..64, default %d)\n"
+        "  --rate HZ        44100 | 48000 | 88200 | 96000 | 176400 | 192000\n"
+        "                   (default %d)\n"
         "  --latency-us N   ALSA period latency hint (default %d)\n"
         "  --no-feedback    do not emit Mode C FEEDBACK frames (diagnostic)\n",
-        prog, DEFAULT_LATENCY_US);
+        prog, DEFAULT_CHANNELS, DEFAULT_RATE_HZ, DEFAULT_LATENCY_US);
 }
 
 static int64_t ts_diff_ns(struct timespec a, struct timespec b)
@@ -76,22 +95,28 @@ int main(int argc, char **argv)
 {
     const char *iface = NULL;
     const char *dac = NULL;
+    int channels = DEFAULT_CHANNELS;
+    int rate_hz = DEFAULT_RATE_HZ;
     int latency_us = DEFAULT_LATENCY_US;
     int feedback_enabled = 1;
 
     static const struct option opts[] = {
         { "iface",       required_argument, 0, 'i' },
         { "dac",         required_argument, 0, 'd' },
+        { "channels",    required_argument, 0, 'C' },
+        { "rate",        required_argument, 0, 'r' },
         { "latency-us",  required_argument, 0, 'l' },
         { "no-feedback", no_argument,       0, 'n' },
         { "help",        no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:l:nh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:C:r:l:nh", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dac = optarg; break;
+        case 'C': channels = atoi(optarg); break;
+        case 'r': rate_hz = atoi(optarg); break;
         case 'l': latency_us = atoi(optarg); break;
         case 'n': feedback_enabled = 0; break;
         case 'h': usage(argv[0]); return 0;
@@ -100,6 +125,14 @@ int main(int argc, char **argv)
     }
     if (!iface || !dac) {
         usage(argv[0]);
+        return 2;
+    }
+    if (channels < 1 || channels > 64) {
+        fprintf(stderr, "receiver: --channels must be 1..64 (got %d)\n", channels);
+        return 2;
+    }
+    if (!rate_supported(rate_hz)) {
+        fprintf(stderr, "receiver: unsupported --rate %d\n", rate_hz);
         return 2;
     }
 
@@ -143,12 +176,16 @@ int main(int argc, char **argv)
     err = snd_pcm_set_params(pcm,
                              SND_PCM_FORMAT_S24_3LE,
                              SND_PCM_ACCESS_RW_INTERLEAVED,
-                             CHANNELS,
-                             SAMPLE_RATE_HZ,
+                             (unsigned int)channels,
+                             (unsigned int)rate_hz,
                              0,              /* disable ALSA soft-resample */
                              (unsigned int)latency_us);
     if (err < 0) {
-        fprintf(stderr, "snd_pcm_set_params: %s\n", snd_strerror(err));
+        fprintf(stderr,
+                "snd_pcm_set_params (ch=%d rate=%d S24_3LE): %s\n"
+                "  (DAC must natively support this configuration; "
+                "AOEther never resamples.)\n",
+                channels, rate_hz, snd_strerror(err));
         return 1;
     }
 
@@ -157,11 +194,11 @@ int main(int argc, char **argv)
 
     fprintf(stderr,
             "receiver: iface=%s dac=%s fmt=S24_3LE ch=%d rate=%d latency_us=%d feedback=%s\n",
-            iface, dac, CHANNELS, SAMPLE_RATE_HZ, latency_us,
+            iface, dac, channels, rate_hz, latency_us,
             feedback_enabled ? "on" : "off");
 
     /* Data-path buffer and counters. */
-    uint8_t buf[2048];
+    uint8_t buf[RX_BUF_BYTES];
     uint32_t last_seq = 0;
     int have_seq = 0;
     uint64_t rx = 0, dropped = 0, lost = 0, underruns = 0;
@@ -220,13 +257,13 @@ int main(int argc, char **argv)
                 (const struct aoe_hdr *)(buf + sizeof(struct ether_header));
             if (!aoe_hdr_valid(hdr) ||
                 hdr->format != AOE_FMT_PCM_S24LE_3 ||
-                hdr->channel_count != CHANNELS) {
+                hdr->channel_count != channels) {
                 dropped++;
                 goto check_feedback;
             }
 
             size_t frames = hdr->payload_count;
-            size_t payload_bytes = frames * CHANNELS * BYTES_PER_SAMPLE;
+            size_t payload_bytes = (size_t)frames * (size_t)channels * BYTES_PER_SAMPLE;
             if ((size_t)n < sizeof(struct ether_header) + AOE_HDR_LEN + payload_bytes) {
                 dropped++;
                 goto check_feedback;
@@ -302,11 +339,12 @@ check_feedback:
         }
 
         double dt_s = (double)dt_ns / 1e9;
-        double rate_hz = (double)(consumed - last_consumed) / dt_s;
+        double rate_est_hz = (double)(consumed - last_consumed) / dt_s;
 
-        /* Sanity band: ±20% of nominal, generous to admit startup transients. */
-        if (rate_hz > 0.8 * SAMPLE_RATE_HZ && rate_hz < 1.2 * SAMPLE_RATE_HZ) {
-            double spms = rate_hz / 1000.0;
+        /* Sanity band: ±20% of configured nominal rate, generous enough to
+         * admit startup transients but tight enough to reject garbage. */
+        if (rate_est_hz > 0.8 * rate_hz && rate_est_hz < 1.2 * rate_hz) {
+            double spms = rate_est_hz / 1000.0;
             uint32_t q = (uint32_t)(spms * 65536.0 + 0.5);
             aoe_c_hdr_build_feedback(fb_hdr, STREAM_ID, fb_seq++, q);
             ssize_t ss = sendto(ctl_sock, fb_frame, sizeof(fb_frame), 0,

--- a/talker/README.md
+++ b/talker/README.md
@@ -24,19 +24,23 @@ Flags:
 
 - `--iface IF` (required) — egress interface, e.g. `eno1`, `enp3s0`.
 - `--dest-mac AA:BB:CC:DD:EE:FF` (required) — receiver's MAC.
-- `--source testtone|wav` — default `testtone` (1 kHz sine, −6 dBFS).
-- `--file PATH` — WAV file when `--source wav`. M1 accepts PCM 48 kHz 2ch 24-bit only; the file loops.
+- `--source testtone|wav|alsa` — default `testtone` (1 kHz sine, −6 dBFS).
+- `--file PATH` — WAV file when `--source wav`. Accepts PCM 24-bit at any of the supported channel counts and rates; the file loops.
+- `--capture hw:CARD=...` — ALSA PCM name when `--source alsa`. Point at one half of a `snd-aloop` pair to receive from Roon/UPnP/PipeWire; see `docs/recipe-*.md`.
+- `--channels N` — channel count (1..64, default 2). Receiver must match.
+- `--rate HZ` — one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Receiver must match.
 
 Needs `CAP_NET_RAW` to open `AF_PACKET`; easiest path is `sudo`.
 
 ## What it does, exactly
 
-- Hardcoded stream: ID `0x0001`, format `0x11` (PCM s24le-3), 2 channels, 48 kHz.
+- Stream ID `0x0001`, format `0x11` (PCM s24le-3). Channels and rate are runtime-configured via `--channels` and `--rate`; defaults match M1 (2 channels, 48 kHz).
 - Emits 1 packet per 125 µs tick from `timerfd`. The timer never retunes.
 - Ethernet II frame, EtherType `0x88B5`, AoE header per [`docs/wire-format.md`](../docs/wire-format.md).
-- `payload_count` is **6 samples per packet nominally, but varies under Mode C feedback** — the talker keeps a fractional sample accumulator driven by the latest FEEDBACK value and writes the integer part into each packet. This is how USB hosts drive async DACs; we extend the same scheme across Ethernet.
+- `payload_count` is **nominally `rate_hz / 8000` samples per packet but varies under Mode C feedback** — the talker keeps a fractional sample accumulator driven by the latest FEEDBACK value and writes the integer part into each packet. This is how USB hosts drive async DACs; we extend the same scheme across Ethernet.
 - Listens for FEEDBACK frames on EtherType `0x88B6` (a second raw socket). Clamps accepted rates to ±1000 ppm of nominal. Reverts to nominal rate if no feedback arrives for 5 s.
-- Presentation-time field is `0` (no PTP in M1).
+- MTU check at startup: configurations whose worst-case packet exceeds 1500 bytes (very high multichannel × hi-res combinations) are rejected with a clear message. Packet splitting for those cases is deferred to a later milestone.
+- Presentation-time field is `0` (no PTP yet; arrives in M3).
 - `last-in-group` flag set on every packet.
 
 ## Stopping

--- a/talker/src/audio_source_wav.c
+++ b/talker/src/audio_source_wav.c
@@ -108,9 +108,17 @@ struct audio_source *audio_source_wav_open(const char *path)
         off += 8 + sz + (sz & 1);
     }
 
-    if (fmt_tag != 1 || channels != 2 || rate != 48000 || bits != 24) {
+    /* M2 accepts any channel count and any supported rate, but the sample
+     * format is still locked to 24-bit little-endian (s24le-3 on the wire). */
+    static const int rates[] = { 44100, 48000, 88200, 96000, 176400, 192000 };
+    int rate_ok = 0;
+    for (size_t i = 0; i < sizeof(rates)/sizeof(rates[0]); i++) {
+        if (rate == rates[i]) { rate_ok = 1; break; }
+    }
+    if (fmt_tag != 1 || channels < 1 || channels > 64 || !rate_ok || bits != 24) {
         fprintf(stderr,
-                "wav: M1 requires PCM 48000 Hz 2ch 24-bit; got tag=%d ch=%d rate=%d bits=%d\n",
+                "wav: need PCM 1..64ch 24-bit at a supported rate "
+                "(44.1/48/88.2/96/176.4/192 kHz); got tag=%d ch=%d rate=%d bits=%d\n",
                 fmt_tag, channels, rate, bits);
         munmap((void *)map, sb.st_size);
         return NULL;

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -19,25 +19,37 @@
 #include <time.h>
 #include <unistd.h>
 
-/* Hardcoded M1 stream parameters (see docs/design.md §"M1 detailed plan"). */
+/* Stream parameters. Channels and rate are runtime-configured from M2 on;
+ * sample format is still locked to s24le-3. See docs/design.md §"M2". */
 #define STREAM_ID             0x0001
-#define SAMPLE_RATE_HZ        48000
-#define CHANNELS              2
 #define BYTES_PER_SAMPLE      3
 #define FORMAT_CODE           AOE_FMT_PCM_S24LE_3
 #define PACKET_PERIOD_NS      125000L          /* 125 µs = 1 USB microframe */
 #define MICROFRAMES_PER_MS    8
-#define NOMINAL_SPM           ((double)SAMPLE_RATE_HZ / 1000.0 / MICROFRAMES_PER_MS)  /* 6.0 */
+
+#define DEFAULT_CHANNELS      2
+#define DEFAULT_RATE_HZ       48000
+
+/* Ethernet II data payload max (frame - eth header) for standard 1500 MTU. */
+#define ETH_MTU_PAYLOAD       1500
 
 /* Safety clamp on feedback-derived rate: ±1000 ppm of nominal. */
 #define RATE_CLAMP_PPM        1000.0
 
-/* Max samples per packet (buffer sizing headroom; nominal 6, drift barely
- * changes it). */
-#define MAX_SAMPLES_PER_PACKET 16
-
 /* Talker reverts to nominal after this long without FEEDBACK. */
 #define FEEDBACK_STALE_MS     5000
+
+static int rate_supported(int hz)
+{
+    switch (hz) {
+    case 44100: case 48000:
+    case 88200: case 96000:
+    case 176400: case 192000:
+        return 1;
+    default:
+        return 0;
+    }
+}
 
 static volatile sig_atomic_t g_stop;
 
@@ -92,12 +104,15 @@ static void usage(const char *prog)
         "  --source testtone|wav|alsa   default: testtone\n"
         "  --file   PATH                WAV file, required with --source wav\n"
         "  --capture hw:CARD=...        ALSA capture device, required with --source alsa\n"
+        "  --channels N                 channel count (1..64, default %d)\n"
+        "  --rate    HZ                 44100|48000|88200|96000|176400|192000 (default %d)\n"
         "\n"
-        "M1 stream is hardcoded 48 kHz / 2ch / s24le-3. Sources must match.\n"
+        "Sample format is s24le-3 (24-bit little-endian packed). Sources must match\n"
+        "channels, rate, and format exactly — AOEther never resamples.\n"
         "For music playback, point --capture at one half of a snd-aloop pair\n"
         "and route Roon/UPnP/AirPlay/PipeWire at the other half; see\n"
         "docs/recipe-*.md.\n",
-        prog);
+        prog, DEFAULT_CHANNELS, DEFAULT_RATE_HZ);
 }
 
 int main(int argc, char **argv)
@@ -107,6 +122,8 @@ int main(int argc, char **argv)
     const char *source = "testtone";
     const char *wav_path = NULL;
     const char *capture_pcm = NULL;
+    int channels = DEFAULT_CHANNELS;
+    int rate_hz = DEFAULT_RATE_HZ;
 
     static const struct option opts[] = {
         { "iface",    required_argument, 0, 'i' },
@@ -114,23 +131,50 @@ int main(int argc, char **argv)
         { "source",   required_argument, 0, 's' },
         { "file",     required_argument, 0, 'f' },
         { "capture",  required_argument, 0, 'c' },
+        { "channels", required_argument, 0, 'C' },
+        { "rate",     required_argument, 0, 'r' },
         { "help",     no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:s:f:c:h", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:s:f:c:C:r:h", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dest_s = optarg; break;
         case 's': source = optarg; break;
         case 'f': wav_path = optarg; break;
         case 'c': capture_pcm = optarg; break;
+        case 'C': channels = atoi(optarg); break;
+        case 'r': rate_hz = atoi(optarg); break;
         case 'h': usage(argv[0]); return 0;
         default:  usage(argv[0]); return 2;
         }
     }
     if (!iface || !dest_s) {
         usage(argv[0]);
+        return 2;
+    }
+    if (channels < 1 || channels > 64) {
+        fprintf(stderr, "talker: --channels must be 1..64 (got %d)\n", channels);
+        return 2;
+    }
+    if (!rate_supported(rate_hz)) {
+        fprintf(stderr, "talker: unsupported --rate %d\n", rate_hz);
+        return 2;
+    }
+
+    /* MTU check: at worst we need nominal samples-per-microframe plus a
+     * small drift margin, times channels × bytes. Plus eth (14) + AoE (16). */
+    const double nominal_spm = (double)rate_hz / 1000.0 / MICROFRAMES_PER_MS;
+    const int max_samples_per_packet = (int)(nominal_spm + 0.5) + 4;
+    const size_t max_payload = (size_t)max_samples_per_packet * channels * BYTES_PER_SAMPLE;
+    const size_t max_frame = sizeof(struct ether_header) + AOE_HDR_LEN + max_payload;
+    if (max_payload + AOE_HDR_LEN > ETH_MTU_PAYLOAD) {
+        fprintf(stderr,
+                "talker: ch=%d rate=%d needs %zu-byte frames — exceeds 1500-byte MTU.\n"
+                "  (Packet splitting for very-high-rate multichannel is deferred; try\n"
+                "  fewer channels or a lower rate. Worst-case payload = %zu B.)\n",
+                channels, rate_hz, max_frame, max_payload);
         return 2;
     }
 
@@ -142,19 +186,27 @@ int main(int argc, char **argv)
 
     struct audio_source *src = NULL;
     if (strcmp(source, "testtone") == 0) {
-        src = audio_source_test_open(CHANNELS, SAMPLE_RATE_HZ, BYTES_PER_SAMPLE);
+        src = audio_source_test_open(channels, rate_hz, BYTES_PER_SAMPLE);
     } else if (strcmp(source, "wav") == 0) {
         if (!wav_path) {
             fprintf(stderr, "talker: --file required with --source wav\n");
             return 2;
         }
         src = audio_source_wav_open(wav_path);
+        if (src && (src->channels != channels || src->rate != rate_hz)) {
+            fprintf(stderr,
+                    "talker: WAV file is ch=%d rate=%d; talker configured ch=%d rate=%d. "
+                    "They must match (no resampling in AOEther).\n",
+                    src->channels, src->rate, channels, rate_hz);
+            src->close(src);
+            return 2;
+        }
     } else if (strcmp(source, "alsa") == 0) {
         if (!capture_pcm) {
             fprintf(stderr, "talker: --capture hw:... required with --source alsa\n");
             return 2;
         }
-        src = audio_source_alsa_open(capture_pcm, CHANNELS, SAMPLE_RATE_HZ);
+        src = audio_source_alsa_open(capture_pcm, channels, rate_hz);
     } else {
         fprintf(stderr, "talker: unknown --source %s\n", source);
         return 2;
@@ -213,9 +265,7 @@ int main(int argc, char **argv)
     signal(SIGINT, on_signal);
     signal(SIGTERM, on_signal);
 
-    const size_t payload_cap = (size_t)CHANNELS * BYTES_PER_SAMPLE * MAX_SAMPLES_PER_PACKET;
-    const size_t frame_cap = sizeof(struct ether_header) + AOE_HDR_LEN + payload_cap;
-    uint8_t *frame = calloc(1, frame_cap);
+    uint8_t *frame = calloc(1, max_frame);
     if (!frame) return 1;
 
     struct ether_header *eth = (struct ether_header *)frame;
@@ -229,15 +279,15 @@ int main(int argc, char **argv)
     fprintf(stderr,
             "talker: iface=%s ifindex=%d\n"
             "        src=%02x:%02x:%02x:%02x:%02x:%02x dst=%02x:%02x:%02x:%02x:%02x:%02x\n"
-            "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal spp=%.1f feedback=on\n",
+            "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_frame=%zuB feedback=on\n",
             iface, ifindex,
             src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
             dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
-            CHANNELS, SAMPLE_RATE_HZ, NOMINAL_SPM);
+            channels, rate_hz, nominal_spm, max_samples_per_packet, max_frame);
 
     /* Mode C talker state: current target samples-per-microframe, fractional
      * accumulator, and bookkeeping for stale-feedback fallback. */
-    double samples_per_microframe = NOMINAL_SPM;
+    double samples_per_microframe = nominal_spm;
     double sample_accum = 0.0;
     struct timespec last_fb_rx_ts = { 0, 0 };
     int have_fb = 0;
@@ -279,8 +329,8 @@ int main(int argc, char **argv)
             double spms = (double)q / 65536.0;
             double new_spm = spms / (double)MICROFRAMES_PER_MS;
 
-            double max_spm = NOMINAL_SPM * (1.0 + RATE_CLAMP_PPM * 1e-6);
-            double min_spm = NOMINAL_SPM * (1.0 - RATE_CLAMP_PPM * 1e-6);
+            double max_spm = nominal_spm * (1.0 + RATE_CLAMP_PPM * 1e-6);
+            double min_spm = nominal_spm * (1.0 - RATE_CLAMP_PPM * 1e-6);
             if (new_spm < min_spm || new_spm > max_spm) {
                 fb_ignored++;
                 continue;
@@ -297,7 +347,7 @@ int main(int argc, char **argv)
             struct timespec now;
             clock_gettime(CLOCK_MONOTONIC, &now);
             if (ts_diff_ms(now, last_fb_rx_ts) > FEEDBACK_STALE_MS) {
-                samples_per_microframe = NOMINAL_SPM;
+                samples_per_microframe = nominal_spm;
                 have_fb = 0;
             }
         }
@@ -318,7 +368,7 @@ int main(int argc, char **argv)
             sample_accum += samples_per_microframe;
             int pc = (int)sample_accum;
             if (pc < 1) pc = 1;
-            if (pc > MAX_SAMPLES_PER_PACKET) pc = MAX_SAMPLES_PER_PACKET;
+            if (pc > max_samples_per_packet) pc = max_samples_per_packet;
             sample_accum -= pc;
 
             if (src->read(src, payload, (size_t)pc) < 0) {
@@ -326,12 +376,12 @@ int main(int argc, char **argv)
                 break;
             }
             aoe_hdr_build(hdr, STREAM_ID, seq, 0,
-                          CHANNELS, FORMAT_CODE, (uint8_t)pc,
+                          (uint8_t)channels, FORMAT_CODE, (uint8_t)pc,
                           AOE_FLAG_LAST_IN_GROUP);
 
             size_t frame_len =
                 sizeof(struct ether_header) + AOE_HDR_LEN
-                + (size_t)pc * CHANNELS * BYTES_PER_SAMPLE;
+                + (size_t)pc * channels * BYTES_PER_SAMPLE;
 
             ssize_t sent = sendto(data_sock, frame, frame_len, 0,
                                   (struct sockaddr *)&data_to, sizeof(data_to));


### PR DESCRIPTION
Add --channels and --rate flags to both talker and receiver, with defaults matching M1 (2 channels, 48 kHz). Supported rates: 44.1, 48, 88.2, 96, 176.4, 192 kHz. Channel counts 1..64. Sample format stays locked at s24le-3 for M2; other widths and DSD arrive later.

Mode C constants now derive from the configured rate: nominal samples per microframe = rate / 8000; the talker ±1000 ppm clamp band scales accordingly; the receiver feedback-sanity band (±20 percent) checks against the configured rate rather than a hardcoded 48 kHz. Fixes a shadowing bug in the prior receiver where a local double rate_hz was being compared against itself, making the sanity check always pass.

Talker adds an MTU check at startup. Worst-case frame = 14 eth + 16 aoe + (nominal_spm + 4 drift margin) * channels * 3 bytes. Reject configurations where that exceeds 1500 bytes with a clear message. This lets 12 ch fit at up to 192 kHz and 16 ch fit at up to 192 kHz with tight margins; 384 kHz multichannel and 768 kHz stereo await packet-splitting work. Frame buffer is now sized from the computed worst case rather than a static MAX_SAMPLES_PER_PACKET define.

audio_source_wav.c loosened from M1 "48k/2ch/24b only" to accept any channels 1..64 and any supported rate at 24-bit. audio_source_alsa.c was already parameterized.

docs/dacs.md new: scaffold for per-DAC test reports (reporting template + reference test sequence) so contributors can fill in known-good configurations as hardware is tested.

docs/design.md M2 section expanded: scope now explicitly covers hi-res rates alongside multichannel; deliverables list includes MTU check, rate-derived Mode C constants, and the DAC test matrix.

README.md: M1 row marked Done, M2 row marked In progress. Per-dir READMEs document the new flags. Recipe docs (roon, upnp, capture, quickstart) pick up multichannel / hi-res sections describing the three-matched-values pattern: source daemon config, talker --rate / --channels, receiver --rate / --channels all must agree.