### PR TITLE
Add M3 Phase A: Tier 2 bring-up and PTP setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You should hear a clean 1 kHz tone.
 |-----------|--------|-------------|
 | M1 | Done | Stereo PCM, RPi + USB DAC, Mode C rate feedback, Roon/UPnP/system-audio bridges, no PTP |
 | M2 | In progress | Multichannel PCM (up to 7.1.4 / 16ch), hi-res rates (up to 192 kHz), per-DAC test matrix |
-| M3 | Planned | Tier 2 hardware (Linux SBC), hardware PTP |
+| M3 | Docs ready | Tier 2 hardware (Linux SBC), hardware PTP (Phase A); hardware validation pending board |
 | M4 | Planned | IP/UDP transport (WiFi and routed networks) |
 | M5 | Planned | AVTP AAF wire format for Milan interop |
 | M6 | Planned | Native DSD64 through DSD512 end-to-end |
@@ -104,6 +104,9 @@ The same talker and receiver binaries run under every recipe; only the source da
 
 - [`docs/design.md`](docs/design.md) — full architecture and milestone plan (start here for reviewers and contributors)
 - [`docs/wire-format.md`](docs/wire-format.md) — wire protocol reference (for implementers)
+- [`docs/tier2-bringup.md`](docs/tier2-bringup.md) — getting the receiver running on an SBC with hardware PTP (M3 prep)
+- [`docs/ptp-setup.md`](docs/ptp-setup.md) — ptp4l / phc2sys configuration (M3 prep)
+- [`docs/dacs.md`](docs/dacs.md) — tested DAC matrix (growing contribution table)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to help
 
 ## License

--- a/docs/design.md
+++ b/docs/design.md
@@ -346,11 +346,26 @@ See the detailed M1 plan below.
 
 ### M3 — Tier 2 hardware, hardware PTP
 
-**Goal:** Bring up same stack on a Tier 2 Linux SBC. Validate sub-µs PTP sync.
+**Goal:** Bring up the same receiver stack on a Tier 2 Linux SBC with hardware-PTP-capable Ethernet. Validate sub-µs `ptp4l` sync. Lay the plumbing for gPTP-disciplined emission (Mode B) and multi-receiver phase alignment.
 
-**Deliverables:** Receiver runs on at least one Tier 2 platform (i.MX 8M Mini recommended). `ptp4l` with hardware timestamping. Two-talker phase alignment measured.
+M3 is split into two sub-phases because it's mostly hardware work:
 
-**Time estimate:** 3–4 weekends, mostly hardware bring-up.
+**Phase A — docs-ready (can land without hardware):**
+- `docs/tier2-bringup.md` — reference platform choice (i.MX 8M Mini), OS choice (Debian 12 arm64 or Yocto), kernel/driver confirmation steps, first-boot checks that exercise the existing M1/M2 receiver on Tier 2 without PTP.
+- `docs/ptp-setup.md` — ptp4l + phc2sys configuration for gPTP (802.1AS) and PTPv2-default profiles; validation against a reference; systemd units for persistent operation; software-fallback mode for Tier 1.
+- No code changes. M1/M2 already runs on Tier 2 as a plain arm64 Debian application — that's a nice property of the Topology B choice.
+
+**Phase B — hardware-required (lands after someone has a Tier 2 board running ptp4l):**
+- Talker `--ptp-clock` / `--presentation-time-offset-ms` flags. When set, `clock_gettime(CLOCK_TAI)` on each emission, stamp `presentation_time = low32(tai_ns + offset_ns)`. Default path unchanged.
+- Receiver `presentation_time`-aware scheduling. Compute target playback time; arrange `snd_pcm_writei()` to hit that target within ALSA's achievable resolution.
+- Statistics on presentation-time arrival jitter for debugging.
+- Measured two-receiver phase alignment on a wired gigabit LAN with a scope; target < 10 µs skew.
+
+**Deliverables:** Both phases. Phase A merges independently; Phase B merges once validated on real hardware.
+
+**Key risks:** Tier 2 hardware bring-up timeline depends on board availability, not on AOEther code complexity. Managed switches often drop PTP silently — documented in `ptp-setup.md`.
+
+**Time estimate:** Phase A 1 weekend (doc writing). Phase B 2–3 weekends once a Tier 2 board is in hand, dominated by ptp4l/phc2sys tuning and scope-based measurement.
 
 ### M4 — IP/UDP transport (WiFi and routed networks)
 

--- a/docs/ptp-setup.md
+++ b/docs/ptp-setup.md
@@ -1,0 +1,210 @@
+# PTP setup for AOEther
+
+This doc covers running `ptp4l` and `phc2sys` on AOEther Tier 1 / Tier 2 hosts so that the talker and receiver(s) share a common time reference. That reference is what AOEther Mode B (M3+) uses to phase-align multiple receivers — see `docs/design.md` §"Clock architecture".
+
+**Scope**: wired LAN only. PTP over WiFi doesn't meaningfully work on commodity hardware; AOEther's Mode C feedback handles single-receiver rate matching over WiFi without PTP, which is the intended answer there.
+
+**Status**: ahead of AOEther code. The talker and receiver binaries do not yet consume `presentation_time` meaningfully. This doc describes the PTP plumbing so that when the code lands, the time source is already working and measurable.
+
+## Two profile choices
+
+PTP has several interoperable profiles. AOEther primarily uses two:
+
+- **gPTP (IEEE 802.1AS-2020)** — Milan and TSN use this. Domain 0, L2 multicast, `delayMechanism P2P`. This is what Mode B assumes by default.
+- **PTPv2 default / IEEE 1588-2019** — Ravenna/AES67 setups use this. UDP-over-IP transport (Modes 3/4), commonly on domain 0 or a site-specific domain. AOEther supports it for AES67 interop in M9.
+
+`linuxptp` handles both. Configuration below shows gPTP first, with notes on PTPv2 variations.
+
+## Hardware vs software timestamping
+
+- **Hardware timestamping** (Tier 2, see `tier2-bringup.md`): the NIC captures precise timestamps as packets cross the MAC. `ptp4l` converges to sub-µs offset against a master on a wired LAN.
+- **Software timestamping** (Tier 1 Pi, common Intel desktop NICs without PTP support): timestamps are captured by the kernel just above the driver. 10–100 µs accuracy typical; enough for M3's "it works at all" bar but not for sub-µs phase alignment.
+
+Check which you have:
+
+```sh
+sudo apt install linuxptp ethtool
+ethtool -T eth0
+```
+
+Look for `SOF_TIMESTAMPING_TX_HARDWARE`, `SOF_TIMESTAMPING_RX_HARDWARE`, `SOF_TIMESTAMPING_RAW_HARDWARE`. If all three are listed, you have hardware PTP. If only the `SOFTWARE` variants are present, you're in software-timestamp mode.
+
+## Roles: master vs slave
+
+In a single-talker setup, the simplest arrangement:
+
+- **Talker** runs `ptp4l` as the grandmaster (best-master-clock algorithm will elect it if nothing better is on the network).
+- **Each receiver** runs `ptp4l` as a slave, syncing its PHC (and via `phc2sys`, its system clock) to the talker.
+
+For production deployments with an existing PTP master (an AVB switch, a dedicated grandmaster, a Milan controller), point everyone at that master instead — the talker becomes a slave too.
+
+## Config files
+
+### Grandmaster (talker side)
+
+`/etc/linuxptp/gPTP-master.conf`:
+
+```ini
+[global]
+# 802.1AS / gPTP profile
+gmCapable               1
+priority1               128
+priority2               128
+logAnnounceInterval     0
+logSyncInterval        -3
+logMinPdelayReqInterval 0
+transportSpecific       0x1
+ptp_dst_mac             01:80:C2:00:00:0E
+network_transport       L2
+delay_mechanism         P2P
+domainNumber            0
+```
+
+Run it:
+
+```sh
+sudo ptp4l -f /etc/linuxptp/gPTP-master.conf -i eth0 -m
+```
+
+`-m` prints to stderr; drop it and use systemd for persistent operation.
+
+### Slave (receiver side)
+
+`/etc/linuxptp/gPTP-slave.conf`:
+
+```ini
+[global]
+# 802.1AS / gPTP profile (slave-capable)
+gmCapable               0
+priority1               255
+priority2               255
+logAnnounceInterval     0
+logSyncInterval        -3
+logMinPdelayReqInterval 0
+transportSpecific       0x1
+ptp_dst_mac             01:80:C2:00:00:0E
+network_transport       L2
+delay_mechanism         P2P
+domainNumber            0
+```
+
+Run it, then discipline the system clock from the PHC:
+
+```sh
+sudo ptp4l -f /etc/linuxptp/gPTP-slave.conf -i eth0 -s -m &
+sudo phc2sys -s eth0 -c CLOCK_REALTIME -w -m &
+# Or, to keep CLOCK_TAI in sync (what AOEther will read), also:
+sudo phc2sys -s eth0 -c CLOCK_TAI -O 0 -w -m &
+```
+
+On glibc, `clock_gettime(CLOCK_TAI, ...)` reads a clock that `phc2sys -c CLOCK_TAI` disciplines against gPTP (which is TAI-based). The AOEther talker will read this clock to populate `presentation_time` once that code lands.
+
+### PTPv2 default profile (for AES67 / Ravenna interop, M9)
+
+Same tooling, different config. `/etc/linuxptp/PTPv2.conf`:
+
+```ini
+[global]
+gmCapable               0
+priority1               248
+priority2               248
+logAnnounceInterval     1
+logSyncInterval        -3
+logMinDelayReqInterval -3
+transportSpecific       0x0
+network_transport       UDPv4
+delay_mechanism         E2E
+domainNumber            0
+```
+
+Note `UDPv4` transport and `E2E` delay mechanism — these are the AES67 conventions. Run on the same Ethernet interface; you can even run gPTP and PTPv2 on different domains simultaneously if your hardware supports multiple PHC contexts.
+
+## Validation
+
+### 1. `ptp4l` slave locks to master
+
+On the slave, after a few seconds:
+
+```
+ptp4l[1234.567]: rms   45 max  182 freq ... delay    50 +/-   5
+```
+
+`rms` should be < 1000 ns on a wired LAN with hardware timestamping, < 100 µs with software timestamping. If it doesn't converge, check firewall (allow L2 multicast for gPTP), switch configuration (many managed switches drop PTP by default — enable "PTP transparent" or disable filtering), and that both sides use the same delay mechanism (P2P).
+
+### 2. `phc2sys` locks system clock to PHC
+
+```
+phc2sys[1234.567]: CLOCK_REALTIME phc offset   -120 s2 freq ... delay    0
+```
+
+`s2` means "servo state 2 = locked". `s0` is the startup state; if it doesn't progress past `s0`, the PHC isn't stable yet.
+
+### 3. Cross-host sanity check
+
+On two slaves, measure their system-clock offset against each other:
+
+```sh
+# On slave A
+date +%s%N
+# On slave B at nearly the same instant
+date +%s%N
+```
+
+Over `ssh` with aligned polling this is noisy (SSH RTT dominates); for a real measurement, emit a PPS or trigger a GPIO from both slaves on the same gPTP-scheduled tick and scope the skew. Sub-µs between two hardware-PTP-slaved endpoints on a well-behaved switch is the target.
+
+### 4. Under-load stability
+
+Real-world test: play music through AOEther for 1 hour while `ptp4l` is running. The `ptp4l` rms should not degrade meaningfully under network load. If it does, suspect the switch's PTP handling (use a TSN-capable switch for serious deployments) or CPU contention on the slave.
+
+## systemd units (persistent operation)
+
+`/etc/systemd/system/ptp4l.service`:
+
+```ini
+[Unit]
+Description=PTP4L on eth0 as slave
+After=network.target
+
+[Service]
+ExecStart=/usr/sbin/ptp4l -f /etc/linuxptp/gPTP-slave.conf -i eth0 -s
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`/etc/systemd/system/phc2sys.service`:
+
+```ini
+[Unit]
+Description=phc2sys CLOCK_TAI from eth0 PHC
+After=ptp4l.service
+
+[Service]
+ExecStart=/usr/sbin/phc2sys -s eth0 -c CLOCK_TAI -O 0 -w
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now ptp4l phc2sys
+```
+
+## Troubleshooting
+
+- **`ptp4l` fails with "hardware timestamping not supported"**: either the NIC lacks PTP hardware (check `ethtool -T`), or the kernel driver doesn't wire it up. For i.MX 8M Mini specifically, the `fec` driver historically had PTP quirks; the ENET_QOS path in recent kernels is the good one. Mainline 6.1+ is recommended.
+- **Sync jumps around by ~1 ms periodically**: something else on the host is slewing the clock. Disable NTP (`systemctl disable chronyd systemd-timesyncd`) when running `phc2sys` — the two will fight.
+- **Master elected on the wrong host**: check BMCA priorities. Lowest `priority1/priority2` wins; make sure the intended master has the smallest values.
+- **Works on a cable, fails through a switch**: the switch is dropping PTP. Consumer switches often mangle timestamps (non-transparent). Use a PTP-aware switch (Cisco, NETGEAR with PTP profile, Ruckus, or any AVB-capable switch) for serious measurements.
+
+## What AOEther reads from this
+
+Eventually the talker will `clock_gettime(CLOCK_TAI, ...)` on each emission tick and stamp `presentation_time = low32(tai_ns + offset_ns)` into the AoE header. The receiver will do the same lookup and schedule playback around that target. Until that code lands, `phc2sys` against `CLOCK_TAI` is useful for:
+
+- Observation: cross-host `date +%s%N` or scoped PPS signals tell you whether PTP is actually working.
+- Preparation: once the code lands, the time source is already disciplined; no additional bring-up needed.
+
+If you don't run PTP at all, AOEther continues to work per M1/M2 semantics — Mode C clock discipline handles single-receiver rate matching on its own.

--- a/docs/tier2-bringup.md
+++ b/docs/tier2-bringup.md
@@ -1,0 +1,134 @@
+# Tier 2 bring-up guide
+
+This is the doc for bringing the AOEther receiver up on a Tier 2 Linux SBC — a board with hardware-PTP-capable Ethernet and enough peripherals to host a USB DAC. Tier 2 is what unlocks gPTP-disciplined emission (Mode B), sub-microsecond clock sync, and multi-receiver phase alignment per `docs/design.md` §M3.
+
+Tier 1 (Raspberry Pi) works fine for single-receiver listening but can't do hardware PTP. Tier 2 closes that gap.
+
+**Status:** This doc is ahead of the code. The existing receiver binary runs on any arm64 Debian/Ubuntu with `libasound2`, so the userspace side is straightforward. The harder pieces — hardware PTP integration, multi-receiver phase alignment — arrive in follow-up work once someone has the board in hand. See the "What still needs code" section at the bottom.
+
+## Reference platform: NXP i.MX 8M Mini
+
+Chosen as the reference because it has the cleanest Linux story for hardware PTP:
+
+- **ENET_QOS** MAC with IEEE 1588v2 hardware timestamping built in.
+- **Mainline kernel support** for the Ethernet MAC, clocks, and USB host — no vendor fork required, though the vendor BSP is often more polished for initial bring-up.
+- **USB 2.0 HS host ports** exposed on most carrier boards. UAC2 DACs work with stock `snd_usb_audio`.
+- **SoM + carrier** form factor from ~$150 (Kontron/Phytec/CompuLab/Variscite SoMs on evaluation carriers).
+
+Any of the following should also work and are secondary targets once the i.MX 8M Mini path is proven:
+
+- **NXP i.MX 8M Plus** SoM — same stack plus a second TSN-capable 1 GbE port; useful for M8 redundancy.
+- **Marvell ClearFog Base** — `mvneta` Ethernet driver, hardware PTP.
+- **TI AM6548 (BeagleBone AI-64)** — mainline support, community-friendly, hardware PTP via the `am65-cpsw` driver.
+
+## Hardware checklist
+
+- SoM with i.MX 8M Mini (Kontron pITX-SMARC-SXAL, Phytec phyBOARD-Polis, Variscite DART-MX8M-MINI on eval carrier, or NXP EVK).
+- USB-A host port (most carriers break out at least one).
+- Ethernet cable to a wired switch — **not** to WiFi, PTP over WiFi doesn't work.
+- A USB DAC for playback.
+- A Tier 1 receiver (Pi) and a talker on the same switch for soak testing.
+- (Optional) A PPS output or scope-capable signal from both the Tier 1 and Tier 2 receivers' DACs for phase-alignment measurement at M3 endgame.
+
+## OS choice
+
+Two reasonable paths:
+
+### Path A: Debian 12 (Bookworm) arm64
+
+Fastest to a working receiver. Works on most commercial SoMs that ship with a Debian image or can boot a generic Debian arm64 image on top of the vendor's U-Boot + kernel.
+
+```sh
+# On the Tier 2 board, after booting Debian arm64:
+sudo apt update
+sudo apt install build-essential libasound2-dev linuxptp
+git clone https://github.com/jab-r/AOEther.git
+cd AOEther
+make
+```
+
+Debian 12 ships a 6.1-series kernel with mainline i.MX 8M Mini Ethernet and PTP support. Confirm with:
+
+```sh
+uname -r      # expect 6.1.x or newer
+ethtool -T eth0
+# Look for: hardware-transmit (SOF_TIMESTAMPING_TX_HARDWARE)
+#           hardware-receive  (SOF_TIMESTAMPING_RX_HARDWARE)
+#           hardware-raw-clock (SOF_TIMESTAMPING_RAW_HARDWARE)
+# If present, hardware PTP is available.
+```
+
+### Path B: Yocto / custom BSP
+
+Better for integration into a product. Longer bring-up. Use NXP's `meta-imx` layers on top of a stock poky. Build a `core-image-base` with `linuxptp`, `alsa-utils`, `libasound`, and the AOEther receiver recipe (TBD). Kernel: whatever LTS the BSP tracks; 6.1 or newer recommended for best mainline-matching PTP behavior.
+
+For M3 docs purposes, Path A is what you want. Path B is the right answer for a shippable product but it doesn't change what the receiver binary itself does.
+
+## First boot checks
+
+Before worrying about PTP, confirm the boring stuff works:
+
+```sh
+aplay -L | grep -A1 '^hw:'
+# Your USB DAC should appear. If not, dmesg for snd_usb_audio errors.
+
+ip link show eth0
+ethtool eth0
+# 1000 Mb/s full duplex on a wired switch.
+```
+
+Then run the receiver in M1/M2 mode (no PTP yet) to confirm the talker → Tier 2 → USB DAC path works:
+
+```sh
+sudo ./receiver/build/receiver \
+    --iface eth0 \
+    --dac hw:CARD=<your-dac>,DEV=0
+```
+
+On the talker elsewhere on the switch:
+
+```sh
+sudo ./talker/build/talker \
+    --iface eno1 \
+    --dest-mac <tier2-mac> \
+    --source testtone
+```
+
+You should hear the 1 kHz tone. `fb_sent` on the receiver should be rising. This validates that everything except PTP works, which is 80% of the bring-up.
+
+## Enabling hardware PTP
+
+See [`ptp-setup.md`](ptp-setup.md) for the full ptp4l/phc2sys configuration. Summary:
+
+1. Confirm `ethtool -T eth0` reports hardware timestamping support (above).
+2. Configure `ptp4l` with a gPTP (802.1AS) profile on eth0 as slave.
+3. Run `phc2sys` to discipline the system clock from the PHC.
+4. Measure offset stability over ~60 s — should converge to sub-µs on a wired LAN.
+
+Once that's in place, the AOEther receiver will be ready for the M3 code changes (see below) that consume `presentation_time`.
+
+## What still needs code
+
+This doc describes the prep. The code work below is what future M3 PRs will deliver once the board is running:
+
+- **Talker:** add `--ptp-clock` / `--presentation-time-offset-ms` flags. When configured, read `CLOCK_TAI` (which `phc2sys` slaves to gPTP) at emission, stamp `presentation_time = low32(current_tai_ns + offset_ns)` in each data frame. Default behavior unchanged.
+- **Receiver:** consume `presentation_time` when non-zero. Compute `target_tai = reconstruct_high_bits(presentation_time, current_tai_ns)`. Schedule `snd_pcm_writei()` such that samples reach the DAC approximately at `target_tai`. ALSA's scheduling is coarse; real accuracy is limited by ALSA period size, not by the wire-format timestamp.
+- **Receiver:** statistics on presentation-time arrival jitter for debugging (log deltas between expected arrival time and actual, per second).
+- **Multi-receiver phase alignment:** with two receivers both running `ptp4l` slave on the same gPTP master, and the talker stamping `presentation_time`, both receivers should present samples within a few µs of each other. Measure with a scope on the DAC analog outputs playing the same click track.
+
+None of those land in this PR; they wait for hardware validation.
+
+## Known deferred from M3
+
+- WiFi timing. Mode B is wired-only; `ptp4l` over WiFi gets 100s of µs at best.
+- Milan interop. Sub-µs sync on Tier 2 opens the door but Milan needs AVTP/AVDECC (M5 / M7).
+- Redundancy (FRER-style). Post-M8 per Appendix C.
+- Productized firmware image. Staying with Debian/Ubuntu for bring-up; Yocto-based shippable image is a separate effort.
+
+## References
+
+- [linuxptp project](https://linuxptp.sourceforge.net/) — `ptp4l`, `phc2sys`, `pmc`.
+- NXP i.MX 8M Mini reference manual — ENET_QOS chapter for PTP registers and timestamp capture semantics.
+- IEEE 802.1AS-2020 — gPTP profile.
+- IEEE 1588-2019 — the broader PTPv2 spec.
+- `Documentation/networking/timestamping.rst` in the Linux kernel tree — how `SO_TIMESTAMPING` surfaces hardware timestamps to userspace.


### PR DESCRIPTION
M3 is primarily a hardware milestone. Split it into two phases so the prep can land now without waiting on a Tier 2 board:

Phase A (this commit, docs only):
  docs/tier2-bringup.md - reference platform (i.MX 8M Mini), OS choice
    (Debian 12 arm64 or Yocto), kernel/driver confirmation, first-boot
    checks that exercise the existing M1/M2 receiver on Tier 2 without
    PTP. Calls out what still needs code (Phase B).
  docs/ptp-setup.md - ptp4l and phc2sys configuration for gPTP (802.1AS)
    and PTPv2-default profiles, validation steps, systemd units for
    persistent operation, software-fallback mode for Tier 1 Pi without
    hardware timestamping. Honest about scope: wired LAN only, WiFi PTP
    does not meaningfully work.

Phase B (deferred, requires hardware):
  - Talker --ptp-clock / --presentation-time-offset-ms flags that read CLOCK_TAI and stamp presentation_time in AoE headers.
  - Receiver presentation_time-aware scheduling.
  - Measured two-receiver phase alignment on a wired gigabit LAN.

Rationale for docs-only split: writing PTP code that is never tested on real hardware risks shipping something that diverges from how gPTP actually behaves. Better to land the runway - Tier 2 board selection, kernel setup, ptp4l config, validation protocol - so whoever picks up the hardware work pushes real, tested code.

design.md M3 section expanded to describe both phases. README milestone row set to "Docs ready" and links added for the new docs.