### PR TITLE
Add IP/UDP transport with IPv6 + multicast + multi-receiver arbitration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You should hear a clean 1 kHz tone.
 | M1 | Done | Stereo PCM, RPi + USB DAC, Mode C rate feedback, Roon/UPnP/system-audio bridges, no PTP |
 | M2 | In progress | Multichannel PCM (up to 7.1.4 / 16ch), hi-res rates (up to 192 kHz), per-DAC test matrix |
 | M3 | Docs ready | Tier 2 hardware (Linux SBC), hardware PTP (Phase A); hardware validation pending board |
-| M4 | Planned | IP/UDP transport (WiFi and routed networks) |
+| M4 | In progress | IP/UDP transport, IPv4+IPv6, unicast+multicast, multi-receiver Mode C arbitration |
 | M5 | Planned | AVTP AAF wire format for Milan interop |
 | M6 | Planned | Native DSD64 through DSD512 end-to-end |
 | M7 | Planned | AVDECC, MCU receiver track kickoff |

--- a/docs/design.md
+++ b/docs/design.md
@@ -367,15 +367,21 @@ M3 is split into two sub-phases because it's mostly hardware work:
 
 **Time estimate:** Phase A 1 weekend (doc writing). Phase B 2–3 weekends once a Tier 2 board is in hand, dominated by ptp4l/phc2sys tuning and scope-based measurement.
 
-### M4 — IP/UDP transport (WiFi and routed networks)
+### M4 — IP/UDP transport (WiFi, routed networks, multicast)
 
-**Goal:** Add IP/UDP transport (Mode 3) alongside the existing L2 mode so streams work over WiFi, across VLANs, and through routers. Same AoE header inside a UDP datagram.
+**Goal:** Add IP/UDP transport (Mode 3) alongside the existing L2 mode so streams work over WiFi, across VLANs, and through routers. Same AoE header inside a UDP datagram. Both IPv4 and IPv6. Both unicast and multicast. Same `snd-aloop` bridge recipes keep working — only the transport wrapper changes.
 
-**Deliverables:** Talker and receiver gain `--transport ip` flag. Unicast UDP works; multicast UDP (for multi-receiver streams) documented and tested for IPv4 and IPv6. DSCP tagging with `EF` for WMM / WiFi QoS. Receiver handles both L2 and IP on the same instance (configurable per stream). End-to-end demo: talker on wired, receiver on Pi connected via WiFi, audio plays cleanly with documented latency and jitter numbers.
+**Deliverables:**
+- Talker and receiver gain `--transport l2|ip`, `--port` flags. Talker adds `--dest-ip` accepting either IPv4 or IPv6 literals. Receiver adds `--group IP` for multicast membership.
+- IPv4 + IPv6 unicast and multicast working end to end. Address family auto-detected from the literal; multicast auto-detected from the address range (`224.0.0.0/4` or `ff00::/8`).
+- DSCP tagging with Expedited Forwarding (0xB8) via `IP_TOS` / `IPV6_TCLASS`. Advisory — improves WMM AC_VO handling on WiFi and DSCP-aware wired switches.
+- Talker-side Mode C arbitration over multiple FEEDBACK sources (up to 16 receivers): take the **slowest** non-stale rate so no receiver xruns. Per-source sequence numbers track independently.
+- Single-socket IP design: talker uses one UDP socket for TX data + RX feedback; receiver uses one for RX data + TX feedback. Magic byte (`0xA0` vs `0xA1`) disambiguates.
+- End-to-end demo: talker on wired, receiver on Pi connected via WiFi, audio plays cleanly with documented latency and jitter numbers. Second demo: talker + two receivers on IPv4 multicast, both playing in lockstep.
 
-**Key risks:** WiFi jitter is highly variable; need to characterize what buffer depth keeps a single-receiver stream glitch-free on typical home WiFi. Multi-receiver phase alignment over WiFi is explicitly not a goal — document clearly.
+**Key risks:** WiFi jitter is highly variable; need to characterize what buffer depth keeps a single-receiver stream glitch-free on typical home WiFi. Multi-receiver phase alignment over WiFi is explicitly not a goal (that needs gPTP, which WiFi can't do) — document clearly. Multicast through consumer home switches sometimes gets flooded as broadcast; mention as a known limitation in recipes.
 
-**Time estimate:** 2–3 weekends including WiFi characterization.
+**Time estimate:** 2–3 weekends including WiFi characterization and multicast testing through at least one consumer switch.
 
 ### M5 — AVTP AAF transport (Milan interop)
 

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -211,7 +211,7 @@ Mode 1 (L2, M1+):
   EtherType = 0x88B6
 ```
 
-Mode 3 (IP/UDP, M4+) will carry AoE-C frames as UDP datagrams on the same port as data frames, disambiguated by magic byte. No IP-level transport is defined in M1.
+Mode 3 (IP/UDP, M4) carries AoE-C frames as UDP datagrams on the same port as data frames (interim 8805), disambiguated by the magic byte (`0xA1` for control vs `0xA0` for data). Feedback always flows unicast from each receiver to the talker, regardless of whether data is carried unicast or multicast; in multicast deployments the talker aggregates FEEDBACK across all subscribed receivers and takes the slowest non-stale rate.
 
 Destination: unicast to the peer's MAC (receiver → talker, talker → receiver for future frame types).
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -32,12 +32,15 @@ sudo ./build/receiver --iface eth0 \
 Flags:
 
 - `--iface IF`, `--dac hw:...` (required) — as above.
+- `--transport l2|ip` — default `l2` (raw Ethernet). `ip` switches to UDP (Mode 3).
+- `--port N` — UDP port to bind (IP mode only, default 8805).
+- `--group IP` — multicast group to join (IP mode only). IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8. Omit for unicast.
 - `--channels N` — channel count (1..64, default 2). Must match the talker.
 - `--rate HZ` — one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Must match the talker.
 - `--latency-us N` — ALSA period latency hint (default 5000 µs). Generous on purpose; the Mode C loop corrects ppm-scale drift slowly and the buffer also absorbs talker-side `timerfd` jitter.
 - `--no-feedback` — disable FEEDBACK emission. **Diagnostic only** — the positive control for the soak test (design.md §M1 test 7): with feedback off, the stream is expected to drift and xrun within minutes, confirming Mode C is doing real work when it's on.
 
-Needs `CAP_NET_RAW` for the raw sockets; easiest path is `sudo`.
+Needs `CAP_NET_RAW` for the raw sockets in L2 mode; easiest path is `sudo`. IP mode doesn't require root for port 8805.
 
 ## What it does, exactly
 

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -7,6 +7,7 @@
 #include <linux/if_packet.h>
 #include <net/ethernet.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdint.h>
@@ -35,6 +36,14 @@
  * (192 kHz microframe) = 1728 B plus 30 B header. 4 KiB is plenty. */
 #define RX_BUF_BYTES     4096
 
+/* IP/UDP default port (interim; see docs/wire-format.md). */
+#define DEFAULT_UDP_PORT  8805
+
+enum transport_mode {
+    TRANSPORT_L2 = 0,
+    TRANSPORT_IP = 1,
+};
+
 static int rate_supported(int hz)
 {
     switch (hz) {
@@ -59,12 +68,16 @@ static void usage(const char *prog)
 {
     fprintf(stderr,
         "usage: %s --iface IF --dac hw:CARD=NAME,DEV=0 [options]\n"
-        "  --channels N     stream channel count (1..64, default %d)\n"
-        "  --rate HZ        44100 | 48000 | 88200 | 96000 | 176400 | 192000\n"
-        "                   (default %d)\n"
-        "  --latency-us N   ALSA period latency hint (default %d)\n"
-        "  --no-feedback    do not emit Mode C FEEDBACK frames (diagnostic)\n",
-        prog, DEFAULT_CHANNELS, DEFAULT_RATE_HZ, DEFAULT_LATENCY_US);
+        "  --transport l2|ip    transport mode, default l2\n"
+        "  --port N             UDP port (IP mode, default %d)\n"
+        "  --group IP           multicast group to join (IP mode, optional;\n"
+        "                       IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8)\n"
+        "  --channels N         stream channel count (1..64, default %d)\n"
+        "  --rate HZ            44100 | 48000 | 88200 | 96000 | 176400 | 192000\n"
+        "                       (default %d)\n"
+        "  --latency-us N       ALSA period latency hint (default %d)\n"
+        "  --no-feedback        do not emit Mode C FEEDBACK frames (diagnostic)\n",
+        prog, DEFAULT_UDP_PORT, DEFAULT_CHANNELS, DEFAULT_RATE_HZ, DEFAULT_LATENCY_US);
 }
 
 static int64_t ts_diff_ns(struct timespec a, struct timespec b)
@@ -95,14 +108,20 @@ int main(int argc, char **argv)
 {
     const char *iface = NULL;
     const char *dac = NULL;
+    const char *group_s = NULL;
     int channels = DEFAULT_CHANNELS;
     int rate_hz = DEFAULT_RATE_HZ;
     int latency_us = DEFAULT_LATENCY_US;
     int feedback_enabled = 1;
+    enum transport_mode transport = TRANSPORT_L2;
+    int udp_port = DEFAULT_UDP_PORT;
 
     static const struct option opts[] = {
         { "iface",       required_argument, 0, 'i' },
         { "dac",         required_argument, 0, 'd' },
+        { "transport",   required_argument, 0, 'T' },
+        { "port",        required_argument, 0, 'P' },
+        { "group",       required_argument, 0, 'G' },
         { "channels",    required_argument, 0, 'C' },
         { "rate",        required_argument, 0, 'r' },
         { "latency-us",  required_argument, 0, 'l' },
@@ -111,10 +130,17 @@ int main(int argc, char **argv)
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:C:r:l:nh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:l:nh", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dac = optarg; break;
+        case 'T':
+            if (strcmp(optarg, "l2") == 0) transport = TRANSPORT_L2;
+            else if (strcmp(optarg, "ip") == 0) transport = TRANSPORT_IP;
+            else { fprintf(stderr, "receiver: --transport must be l2 or ip\n"); return 2; }
+            break;
+        case 'P': udp_port = atoi(optarg); break;
+        case 'G': group_s = optarg; break;
         case 'C': channels = atoi(optarg); break;
         case 'r': rate_hz = atoi(optarg); break;
         case 'l': latency_us = atoi(optarg); break;
@@ -127,6 +153,14 @@ int main(int argc, char **argv)
         usage(argv[0]);
         return 2;
     }
+    if (udp_port < 1 || udp_port > 65535) {
+        fprintf(stderr, "receiver: --port out of range\n");
+        return 2;
+    }
+    if (transport == TRANSPORT_L2 && group_s) {
+        fprintf(stderr, "receiver: --group only makes sense with --transport ip\n");
+        return 2;
+    }
     if (channels < 1 || channels > 64) {
         fprintf(stderr, "receiver: --channels must be 1..64 (got %d)\n", channels);
         return 2;
@@ -136,34 +170,120 @@ int main(int argc, char **argv)
         return 2;
     }
 
-    /* Data socket: receives audio frames on EtherType 0x88B5. */
-    int data_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_ETHERTYPE));
-    if (data_sock < 0) {
-        perror("socket(AF_PACKET, SOCK_RAW) data");
-        fprintf(stderr, "receiver: raw sockets need CAP_NET_RAW (try sudo)\n");
-        return 1;
-    }
-    int ifindex;
-    uint8_t my_mac[6];
-    if (iface_lookup(data_sock, iface, &ifindex, my_mac) < 0) {
-        return 1;
-    }
-    struct sockaddr_ll bind_ll = {
-        .sll_family = AF_PACKET,
-        .sll_protocol = htons(AOE_ETHERTYPE),
-        .sll_ifindex = ifindex,
-    };
-    if (bind(data_sock, (struct sockaddr *)&bind_ll, sizeof(bind_ll)) < 0) {
-        perror("bind(data_sock)");
-        return 1;
-    }
+    /* Socket setup per transport. L2 keeps two raw AF_PACKET sockets (one
+     * per EtherType). IP uses one SOCK_DGRAM socket bound to udp_port —
+     * receives data and sends FEEDBACK; magic byte distinguishes. */
+    int data_sock = -1;
+    int ctl_sock = -1;    /* == data_sock in IP mode */
+    int ifindex = 0;
+    uint8_t my_mac[6] = {0};
+    int group_family = AF_UNSPEC;
+    int use_multicast = 0;
 
-    /* Control socket: sends FEEDBACK frames on EtherType 0x88B6.
-     * Bound with the control protocol so TX uses the right sll_protocol. */
-    int ctl_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_C_ETHERTYPE));
-    if (ctl_sock < 0) {
-        perror("socket(AF_PACKET, SOCK_RAW) control");
-        return 1;
+    if (transport == TRANSPORT_L2) {
+        data_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_ETHERTYPE));
+        if (data_sock < 0) {
+            perror("socket(AF_PACKET, SOCK_RAW) data");
+            fprintf(stderr, "receiver: raw sockets need CAP_NET_RAW (try sudo)\n");
+            return 1;
+        }
+        if (iface_lookup(data_sock, iface, &ifindex, my_mac) < 0) return 1;
+        struct sockaddr_ll bind_ll = {
+            .sll_family = AF_PACKET,
+            .sll_protocol = htons(AOE_ETHERTYPE),
+            .sll_ifindex = ifindex,
+        };
+        if (bind(data_sock, (struct sockaddr *)&bind_ll, sizeof(bind_ll)) < 0) {
+            perror("bind(data_sock)");
+            return 1;
+        }
+        ctl_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_C_ETHERTYPE));
+        if (ctl_sock < 0) {
+            perror("socket(AF_PACKET, SOCK_RAW) control");
+            return 1;
+        }
+    } else {
+        /* Decide v4 vs v6 by --group (if any) or default to v4. */
+        struct in_addr  group_v4 = { 0 };
+        struct in6_addr group_v6 = { 0 };
+        int family = AF_INET;
+        if (group_s) {
+            if (inet_pton(AF_INET, group_s, &group_v4) == 1) {
+                family = AF_INET;
+                uint8_t first = ((uint8_t *)&group_v4)[0];
+                use_multicast = (first >= 224 && first <= 239);
+                if (!use_multicast) {
+                    fprintf(stderr, "receiver: --group %s is not IPv4 multicast (224/4)\n", group_s);
+                    return 2;
+                }
+            } else if (inet_pton(AF_INET6, group_s, &group_v6) == 1) {
+                family = AF_INET6;
+                use_multicast = (group_v6.s6_addr[0] == 0xff);
+                if (!use_multicast) {
+                    fprintf(stderr, "receiver: --group %s is not IPv6 multicast (ff00::/8)\n", group_s);
+                    return 2;
+                }
+            } else {
+                fprintf(stderr, "receiver: --group %s is not a valid IP literal\n", group_s);
+                return 2;
+            }
+        }
+        group_family = family;
+
+        data_sock = socket(family, SOCK_DGRAM, 0);
+        if (data_sock < 0) {
+            perror("socket(AF_INET*, SOCK_DGRAM)");
+            return 1;
+        }
+
+        /* SO_REUSEADDR lets multiple receivers bind the same port on a
+         * multicast group. */
+        int one = 1;
+        setsockopt(data_sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+        /* Interface ifindex needed for multicast membership. */
+        if (iface_lookup(data_sock, iface, &ifindex, my_mac) < 0) return 1;
+
+        if (family == AF_INET) {
+            struct sockaddr_in bind_sin = { .sin_family = AF_INET };
+            bind_sin.sin_addr.s_addr = htonl(INADDR_ANY);
+            bind_sin.sin_port = htons((uint16_t)udp_port);
+            if (bind(data_sock, (struct sockaddr *)&bind_sin, sizeof(bind_sin)) < 0) {
+                perror("bind(udp v4)");
+                return 1;
+            }
+            if (use_multicast) {
+                struct ip_mreqn mreq;
+                memset(&mreq, 0, sizeof(mreq));
+                mreq.imr_multiaddr = group_v4;
+                mreq.imr_ifindex = ifindex;
+                if (setsockopt(data_sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                               &mreq, sizeof(mreq)) < 0) {
+                    perror("setsockopt(IP_ADD_MEMBERSHIP)");
+                    return 1;
+                }
+            }
+        } else {
+            struct sockaddr_in6 bind_sin6 = { .sin6_family = AF_INET6 };
+            bind_sin6.sin6_addr = in6addr_any;
+            bind_sin6.sin6_port = htons((uint16_t)udp_port);
+            if (bind(data_sock, (struct sockaddr *)&bind_sin6, sizeof(bind_sin6)) < 0) {
+                perror("bind(udp v6)");
+                return 1;
+            }
+            if (use_multicast) {
+                struct ipv6_mreq mreq6;
+                memset(&mreq6, 0, sizeof(mreq6));
+                mreq6.ipv6mr_multiaddr = group_v6;
+                mreq6.ipv6mr_interface = (unsigned)ifindex;
+                if (setsockopt(data_sock, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+                               &mreq6, sizeof(mreq6)) < 0) {
+                    perror("setsockopt(IPV6_JOIN_GROUP)");
+                    return 1;
+                }
+            }
+        }
+        ctl_sock = data_sock;   /* one socket for RX data and TX feedback */
     }
 
     /* ALSA: open DAC, set the M1-hardcoded format. */
@@ -192,10 +312,23 @@ int main(int argc, char **argv)
     signal(SIGINT, on_signal);
     signal(SIGTERM, on_signal);
 
-    fprintf(stderr,
-            "receiver: iface=%s dac=%s fmt=S24_3LE ch=%d rate=%d latency_us=%d feedback=%s\n",
-            iface, dac, channels, rate_hz, latency_us,
-            feedback_enabled ? "on" : "off");
+    if (transport == TRANSPORT_L2) {
+        fprintf(stderr,
+                "receiver: transport=l2 iface=%s dac=%s fmt=S24_3LE ch=%d rate=%d latency_us=%d feedback=%s\n",
+                iface, dac, channels, rate_hz, latency_us,
+                feedback_enabled ? "on" : "off");
+    } else {
+        fprintf(stderr,
+                "receiver: transport=ip family=%s %s port=%d%s%s\n"
+                "          iface=%s dac=%s fmt=S24_3LE ch=%d rate=%d latency_us=%d feedback=%s\n",
+                group_family == AF_INET6 ? "v6" : "v4",
+                use_multicast ? "multicast" : "unicast",
+                udp_port,
+                group_s ? " group=" : "",
+                group_s ? group_s : "",
+                iface, dac, channels, rate_hz, latency_us,
+                feedback_enabled ? "on" : "off");
+    }
 
     /* Data-path buffer and counters. */
     uint8_t buf[RX_BUF_BYTES];
@@ -209,22 +342,31 @@ int main(int argc, char **argv)
     struct timespec last_fb_ts = { 0, 0 };
     int rate_bootstrapped = 0;
 
+    /* Talker address as learned from the first valid data frame. For L2
+     * this is a MAC; for IP it's a sockaddr_storage + port. */
     uint8_t talker_mac[6];
-    int have_talker_mac = 0;
+    struct sockaddr_storage talker_addr;
+    socklen_t talker_addr_len = 0;
+    int have_talker = 0;
 
     uint16_t fb_seq = 0;
     uint64_t fb_sent = 0;
 
-    /* Pre-built feedback frame template (28 bytes; kernel pads to 60). */
+    /* Feedback frame template: for L2 it's Ethernet+AoE-C (30B, kernel pads
+     * to 60); for IP it's just AoE-C (16B), kernel adds UDP/IP. */
     uint8_t fb_frame[60];
     memset(fb_frame, 0, sizeof(fb_frame));
     struct ether_header *fb_eth = (struct ether_header *)fb_frame;
-    struct aoe_c_hdr *fb_hdr =
+    struct aoe_c_hdr *fb_hdr_l2 =
         (struct aoe_c_hdr *)(fb_frame + sizeof(struct ether_header));
-    memcpy(fb_eth->ether_shost, my_mac, 6);
-    fb_eth->ether_type = htons(AOE_C_ETHERTYPE);
+    struct aoe_c_hdr *fb_hdr_ip =
+        (struct aoe_c_hdr *)fb_frame;
+    if (transport == TRANSPORT_L2) {
+        memcpy(fb_eth->ether_shost, my_mac, 6);
+        fb_eth->ether_type = htons(AOE_C_ETHERTYPE);
+    }
 
-    struct sockaddr_ll fb_to = {
+    struct sockaddr_ll fb_to_ll = {
         .sll_family = AF_PACKET,
         .sll_protocol = htons(AOE_C_ETHERTYPE),
         .sll_ifindex = ifindex,
@@ -242,19 +384,28 @@ int main(int argc, char **argv)
         }
 
         if (pfd.revents & POLLIN) {
-            ssize_t n = recv(data_sock, buf, sizeof(buf), 0);
+            struct sockaddr_storage src_addr;
+            socklen_t src_addrlen = sizeof(src_addr);
+            ssize_t n;
+            if (transport == TRANSPORT_L2) {
+                n = recv(data_sock, buf, sizeof(buf), 0);
+            } else {
+                n = recvfrom(data_sock, buf, sizeof(buf), 0,
+                             (struct sockaddr *)&src_addr, &src_addrlen);
+            }
             if (n < 0) {
                 if (errno == EINTR) continue;
                 perror("recv");
                 break;
             }
-            if ((size_t)n < sizeof(struct ether_header) + AOE_HDR_LEN) {
+
+            size_t hdr_off = (transport == TRANSPORT_L2) ? sizeof(struct ether_header) : 0;
+            if ((size_t)n < hdr_off + AOE_HDR_LEN) {
                 dropped++;
                 goto check_feedback;
             }
-            const struct ether_header *eth = (const struct ether_header *)buf;
             const struct aoe_hdr *hdr =
-                (const struct aoe_hdr *)(buf + sizeof(struct ether_header));
+                (const struct aoe_hdr *)(buf + hdr_off);
             if (!aoe_hdr_valid(hdr) ||
                 hdr->format != AOE_FMT_PCM_S24LE_3 ||
                 hdr->channel_count != channels) {
@@ -264,7 +415,7 @@ int main(int argc, char **argv)
 
             size_t frames = hdr->payload_count;
             size_t payload_bytes = (size_t)frames * (size_t)channels * BYTES_PER_SAMPLE;
-            if ((size_t)n < sizeof(struct ether_header) + AOE_HDR_LEN + payload_bytes) {
+            if ((size_t)n < hdr_off + AOE_HDR_LEN + payload_bytes) {
                 dropped++;
                 goto check_feedback;
             }
@@ -277,19 +428,24 @@ int main(int argc, char **argv)
             last_seq = seq;
             have_seq = 1;
 
-            if (!have_talker_mac) {
-                memcpy(talker_mac, eth->ether_shost, 6);
-                memcpy(fb_eth->ether_dhost, talker_mac, 6);
-                memcpy(fb_to.sll_addr, talker_mac, 6);
-                have_talker_mac = 1;
+            if (!have_talker) {
+                if (transport == TRANSPORT_L2) {
+                    const struct ether_header *eth = (const struct ether_header *)buf;
+                    memcpy(talker_mac, eth->ether_shost, 6);
+                    memcpy(fb_eth->ether_dhost, talker_mac, 6);
+                    memcpy(fb_to_ll.sll_addr, talker_mac, 6);
+                } else {
+                    memcpy(&talker_addr, &src_addr, src_addrlen);
+                    talker_addr_len = src_addrlen;
+                }
+                have_talker = 1;
             }
 
-            const uint8_t *payload = buf + sizeof(struct ether_header) + AOE_HDR_LEN;
+            const uint8_t *payload = buf + hdr_off + AOE_HDR_LEN;
             snd_pcm_sframes_t w = snd_pcm_writei(pcm, payload, frames);
             if (w == -EPIPE) {
                 underruns++;
                 snd_pcm_prepare(pcm);
-                /* Rate estimator must re-seed after xrun. */
                 rate_bootstrapped = 0;
             } else if (w < 0) {
                 int r = snd_pcm_recover(pcm, (int)w, 1);
@@ -305,7 +461,7 @@ int main(int argc, char **argv)
         }
 
 check_feedback:
-        if (!feedback_enabled || !have_talker_mac) {
+        if (!feedback_enabled || !have_talker) {
             continue;
         }
 
@@ -341,16 +497,20 @@ check_feedback:
         double dt_s = (double)dt_ns / 1e9;
         double rate_est_hz = (double)(consumed - last_consumed) / dt_s;
 
-        /* Sanity band: ±20% of configured nominal rate, generous enough to
-         * admit startup transients but tight enough to reject garbage. */
         if (rate_est_hz > 0.8 * rate_hz && rate_est_hz < 1.2 * rate_hz) {
             double spms = rate_est_hz / 1000.0;
             uint32_t q = (uint32_t)(spms * 65536.0 + 0.5);
-            aoe_c_hdr_build_feedback(fb_hdr, STREAM_ID, fb_seq++, q);
-            ssize_t ss = sendto(ctl_sock, fb_frame, sizeof(fb_frame), 0,
-                                (struct sockaddr *)&fb_to, sizeof(fb_to));
+            ssize_t ss;
+            if (transport == TRANSPORT_L2) {
+                aoe_c_hdr_build_feedback(fb_hdr_l2, STREAM_ID, fb_seq++, q);
+                ss = sendto(ctl_sock, fb_frame, sizeof(fb_frame), 0,
+                            (struct sockaddr *)&fb_to_ll, sizeof(fb_to_ll));
+            } else {
+                aoe_c_hdr_build_feedback(fb_hdr_ip, STREAM_ID, fb_seq++, q);
+                ss = sendto(ctl_sock, fb_frame, AOE_C_HDR_LEN, 0,
+                            (struct sockaddr *)&talker_addr, talker_addr_len);
+            }
             if (ss < 0 && errno != EINTR) {
-                /* Don't bail on transient ctl-path errors; keep playing audio. */
                 perror("sendto(feedback)");
             } else {
                 fb_sent++;
@@ -371,7 +531,7 @@ check_feedback:
 
     snd_pcm_drain(pcm);
     snd_pcm_close(pcm);
-    close(ctl_sock);
+    if (ctl_sock != data_sock) close(ctl_sock);
     close(data_sock);
     return 0;
 }

--- a/talker/README.md
+++ b/talker/README.md
@@ -23,14 +23,17 @@ sudo ./build/talker --iface eno1 \
 Flags:
 
 - `--iface IF` (required) — egress interface, e.g. `eno1`, `enp3s0`.
-- `--dest-mac AA:BB:CC:DD:EE:FF` (required) — receiver's MAC.
+- `--transport l2|ip` — default `l2` (raw Ethernet). `ip` switches to UDP (Mode 3).
+- `--dest-mac AA:BB:CC:DD:EE:FF` — receiver's MAC (required with `--transport l2`).
+- `--dest-ip IP` — destination IPv4 or IPv6 literal (required with `--transport ip`). Multicast groups (224.0.0.0/4 or ff00::/8) are auto-detected.
+- `--port N` — UDP port (IP mode only, default 8805).
 - `--source testtone|wav|alsa` — default `testtone` (1 kHz sine, −6 dBFS).
 - `--file PATH` — WAV file when `--source wav`. Accepts PCM 24-bit at any of the supported channel counts and rates; the file loops.
 - `--capture hw:CARD=...` — ALSA PCM name when `--source alsa`. Point at one half of a `snd-aloop` pair to receive from Roon/UPnP/PipeWire; see `docs/recipe-*.md`.
 - `--channels N` — channel count (1..64, default 2). Receiver must match.
 - `--rate HZ` — one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Receiver must match.
 
-Needs `CAP_NET_RAW` to open `AF_PACKET`; easiest path is `sudo`.
+Needs `CAP_NET_RAW` to open `AF_PACKET` in L2 mode; easiest path is `sudo`. IP mode doesn't require root in principle (bind on ephemeral port is unprivileged), but if you want to bind to port 8805 < 1024 you'd need capabilities anyway — 8805 is fine without.
 
 ## What it does, exactly
 

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -8,6 +8,8 @@
 #include <linux/if_packet.h>
 #include <net/ethernet.h>
 #include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -32,6 +34,17 @@
 
 /* Ethernet II data payload max (frame - eth header) for standard 1500 MTU. */
 #define ETH_MTU_PAYLOAD       1500
+
+/* IP/UDP transport default port (interim; IANA TBD per docs/wire-format.md). */
+#define DEFAULT_UDP_PORT      8805
+
+/* DSCP Expedited Forwarding = 46 (0xB8 when shifted into TOS byte). */
+#define DSCP_EF_TOS           0xB8
+
+enum transport_mode {
+    TRANSPORT_L2 = 0,   /* raw Ethernet, AF_PACKET, EtherType 0x88B5/0x88B6 */
+    TRANSPORT_IP = 1,   /* UDP over IPv4, magic-byte disambiguation */
+};
 
 /* Safety clamp on feedback-derived rate: ±1000 ppm of nominal. */
 #define RATE_CLAMP_PPM        1000.0
@@ -100,10 +113,21 @@ static int64_t ts_diff_ms(struct timespec a, struct timespec b)
 static void usage(const char *prog)
 {
     fprintf(stderr,
-        "usage: %s --iface IF --dest-mac AA:BB:CC:DD:EE:FF [options]\n"
+        "usage: %s --iface IF [transport options] [stream options]\n"
+        "\n"
+        "Transport (pick one):\n"
+        "  --transport l2               raw Ethernet, default\n"
+        "    --dest-mac AA:BB:CC:DD:EE:FF    (required)\n"
+        "  --transport ip               UDP over IPv4 (Mode 3, M4)\n"
+        "    --dest-ip X.Y.Z.W               (required)\n"
+        "    --port N                        UDP port, default %d\n"
+        "\n"
+        "Source:\n"
         "  --source testtone|wav|alsa   default: testtone\n"
         "  --file   PATH                WAV file, required with --source wav\n"
         "  --capture hw:CARD=...        ALSA capture device, required with --source alsa\n"
+        "\n"
+        "Stream format:\n"
         "  --channels N                 channel count (1..64, default %d)\n"
         "  --rate    HZ                 44100|48000|88200|96000|176400|192000 (default %d)\n"
         "\n"
@@ -112,35 +136,48 @@ static void usage(const char *prog)
         "For music playback, point --capture at one half of a snd-aloop pair\n"
         "and route Roon/UPnP/AirPlay/PipeWire at the other half; see\n"
         "docs/recipe-*.md.\n",
-        prog, DEFAULT_CHANNELS, DEFAULT_RATE_HZ);
+        prog, DEFAULT_UDP_PORT, DEFAULT_CHANNELS, DEFAULT_RATE_HZ);
 }
 
 int main(int argc, char **argv)
 {
     const char *iface = NULL;
-    const char *dest_s = NULL;
+    const char *dest_mac_s = NULL;
+    const char *dest_ip_s = NULL;
     const char *source = "testtone";
     const char *wav_path = NULL;
     const char *capture_pcm = NULL;
     int channels = DEFAULT_CHANNELS;
     int rate_hz = DEFAULT_RATE_HZ;
+    enum transport_mode transport = TRANSPORT_L2;
+    int udp_port = DEFAULT_UDP_PORT;
 
     static const struct option opts[] = {
-        { "iface",    required_argument, 0, 'i' },
-        { "dest-mac", required_argument, 0, 'd' },
-        { "source",   required_argument, 0, 's' },
-        { "file",     required_argument, 0, 'f' },
-        { "capture",  required_argument, 0, 'c' },
-        { "channels", required_argument, 0, 'C' },
-        { "rate",     required_argument, 0, 'r' },
-        { "help",     no_argument,       0, 'h' },
+        { "iface",     required_argument, 0, 'i' },
+        { "dest-mac",  required_argument, 0, 'd' },
+        { "dest-ip",   required_argument, 0, 'I' },
+        { "transport", required_argument, 0, 'T' },
+        { "port",      required_argument, 0, 'P' },
+        { "source",    required_argument, 0, 's' },
+        { "file",      required_argument, 0, 'f' },
+        { "capture",   required_argument, 0, 'c' },
+        { "channels",  required_argument, 0, 'C' },
+        { "rate",      required_argument, 0, 'r' },
+        { "help",      no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:s:f:c:C:r:h", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:I:T:P:s:f:c:C:r:h", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
-        case 'd': dest_s = optarg; break;
+        case 'd': dest_mac_s = optarg; break;
+        case 'I': dest_ip_s = optarg; break;
+        case 'T':
+            if (strcmp(optarg, "l2") == 0) transport = TRANSPORT_L2;
+            else if (strcmp(optarg, "ip") == 0) transport = TRANSPORT_IP;
+            else { fprintf(stderr, "talker: --transport must be l2 or ip\n"); return 2; }
+            break;
+        case 'P': udp_port = atoi(optarg); break;
         case 's': source = optarg; break;
         case 'f': wav_path = optarg; break;
         case 'c': capture_pcm = optarg; break;
@@ -150,8 +187,20 @@ int main(int argc, char **argv)
         default:  usage(argv[0]); return 2;
         }
     }
-    if (!iface || !dest_s) {
+    if (!iface) {
         usage(argv[0]);
+        return 2;
+    }
+    if (transport == TRANSPORT_L2 && !dest_mac_s) {
+        fprintf(stderr, "talker: --dest-mac required for --transport l2\n");
+        return 2;
+    }
+    if (transport == TRANSPORT_IP && !dest_ip_s) {
+        fprintf(stderr, "talker: --dest-ip required for --transport ip\n");
+        return 2;
+    }
+    if (udp_port < 1 || udp_port > 65535) {
+        fprintf(stderr, "talker: --port out of range\n");
         return 2;
     }
     if (channels < 1 || channels > 64) {
@@ -178,10 +227,47 @@ int main(int argc, char **argv)
         return 2;
     }
 
+    /* Destination resolution. Exactly one of (dest_mac) or (dest_ss) is
+     * populated depending on transport. For IP, auto-detect v4/v6 and
+     * unicast/multicast from the literal in --dest-ip. */
     uint8_t dest_mac[6];
-    if (parse_mac(dest_s, dest_mac) < 0) {
-        fprintf(stderr, "talker: bad --dest-mac\n");
-        return 2;
+    struct sockaddr_storage dest_ss;
+    socklen_t dest_ss_len = 0;
+    int dest_family = AF_UNSPEC;
+    int dest_is_multicast = 0;
+    memset(&dest_ss, 0, sizeof(dest_ss));
+
+    if (transport == TRANSPORT_L2) {
+        if (parse_mac(dest_mac_s, dest_mac) < 0) {
+            fprintf(stderr, "talker: bad --dest-mac\n");
+            return 2;
+        }
+    } else {
+        struct in_addr v4;
+        struct in6_addr v6;
+        if (inet_pton(AF_INET, dest_ip_s, &v4) == 1) {
+            dest_family = AF_INET;
+            struct sockaddr_in *sin = (struct sockaddr_in *)&dest_ss;
+            sin->sin_family = AF_INET;
+            sin->sin_port = htons((uint16_t)udp_port);
+            sin->sin_addr = v4;
+            dest_ss_len = sizeof(*sin);
+            /* IPv4 multicast = 224.0.0.0/4 (first octet 224..239). */
+            uint8_t first = ((uint8_t *)&v4)[0];
+            dest_is_multicast = (first >= 224 && first <= 239);
+        } else if (inet_pton(AF_INET6, dest_ip_s, &v6) == 1) {
+            dest_family = AF_INET6;
+            struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&dest_ss;
+            sin6->sin6_family = AF_INET6;
+            sin6->sin6_port = htons((uint16_t)udp_port);
+            sin6->sin6_addr = v6;
+            dest_ss_len = sizeof(*sin6);
+            /* IPv6 multicast = ff00::/8. */
+            dest_is_multicast = (v6.s6_addr[0] == 0xff);
+        } else {
+            fprintf(stderr, "talker: --dest-ip %s is neither IPv4 nor IPv6\n", dest_ip_s);
+            return 2;
+        }
     }
 
     struct audio_source *src = NULL;
@@ -213,43 +299,129 @@ int main(int argc, char **argv)
     }
     if (!src) return 1;
 
-    /* Data socket: sends audio on EtherType 0x88B5. */
-    int data_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_ETHERTYPE));
-    if (data_sock < 0) {
-        perror("socket(AF_PACKET, SOCK_RAW) data");
-        fprintf(stderr, "talker: raw sockets need CAP_NET_RAW (try sudo)\n");
-        return 1;
-    }
+    /* Socket setup. L2 mode uses two AF_PACKET raw sockets (one per
+     * EtherType). IP mode uses one AF_INET/AF_INET6 UDP socket for both
+     * TX data and RX feedback, distinguished by magic byte (0xA0 vs 0xA1). */
+    int data_sock = -1;
+    int fb_sock = -1;      /* == data_sock in IP mode */
+    int ifindex = 0;
+    uint8_t src_mac[6] = {0};
+    struct sockaddr_ll data_to_ll = {0};   /* used only in L2 */
 
-    int ifindex;
-    uint8_t src_mac[6];
-    if (iface_lookup(data_sock, iface, &ifindex, src_mac) < 0) return 1;
+    if (transport == TRANSPORT_L2) {
+        data_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_ETHERTYPE));
+        if (data_sock < 0) {
+            perror("socket(AF_PACKET, SOCK_RAW) data");
+            fprintf(stderr, "talker: raw sockets need CAP_NET_RAW (try sudo)\n");
+            return 1;
+        }
+        if (iface_lookup(data_sock, iface, &ifindex, src_mac) < 0) return 1;
 
-    struct sockaddr_ll data_to = {
-        .sll_family = AF_PACKET,
-        .sll_protocol = htons(AOE_ETHERTYPE),
-        .sll_ifindex = ifindex,
-        .sll_halen = 6,
-    };
-    memcpy(data_to.sll_addr, dest_mac, 6);
+        data_to_ll.sll_family = AF_PACKET;
+        data_to_ll.sll_protocol = htons(AOE_ETHERTYPE);
+        data_to_ll.sll_ifindex = ifindex;
+        data_to_ll.sll_halen = 6;
+        memcpy(data_to_ll.sll_addr, dest_mac, 6);
 
-    /* Feedback socket: receives FEEDBACK on EtherType 0x88B6. */
-    int fb_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_C_ETHERTYPE));
-    if (fb_sock < 0) {
-        perror("socket(AF_PACKET, SOCK_RAW) feedback");
-        return 1;
+        fb_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_C_ETHERTYPE));
+        if (fb_sock < 0) {
+            perror("socket(AF_PACKET, SOCK_RAW) feedback");
+            return 1;
+        }
+        struct sockaddr_ll fb_bind = {
+            .sll_family = AF_PACKET,
+            .sll_protocol = htons(AOE_C_ETHERTYPE),
+            .sll_ifindex = ifindex,
+        };
+        if (bind(fb_sock, (struct sockaddr *)&fb_bind, sizeof(fb_bind)) < 0) {
+            perror("bind(fb_sock)");
+            return 1;
+        }
+        int fl = fcntl(fb_sock, F_GETFL, 0);
+        if (fl >= 0) fcntl(fb_sock, F_SETFL, fl | O_NONBLOCK);
+    } else {
+        /* IP/UDP mode. Single SOCK_DGRAM socket, bound to port 0 (kernel
+         * picks local port) so the receiver can learn our (ip,port) from
+         * the source address of our data datagrams and FEEDBACK returns
+         * flow back on the same socket. */
+        data_sock = socket(dest_family, SOCK_DGRAM, 0);
+        if (data_sock < 0) {
+            perror("socket(AF_INET*, SOCK_DGRAM)");
+            return 1;
+        }
+        if (iface_lookup(data_sock, iface, &ifindex, src_mac) < 0) return 1;
+
+        /* DSCP EF: encourages WMM AC_VO on WiFi, priority queueing on
+         * DSCP-aware wired switches. Advisory. */
+        int tos = DSCP_EF_TOS;
+        if (dest_family == AF_INET) {
+            if (setsockopt(data_sock, IPPROTO_IP, IP_TOS, &tos, sizeof(tos)) < 0) {
+                perror("setsockopt(IP_TOS)");
+                /* non-fatal */
+            }
+        } else {
+            int tclass = DSCP_EF_TOS;
+            if (setsockopt(data_sock, IPPROTO_IPV6, IPV6_TCLASS,
+                           &tclass, sizeof(tclass)) < 0) {
+                perror("setsockopt(IPV6_TCLASS)");
+            }
+        }
+
+        if (dest_is_multicast) {
+            /* Outgoing multicast interface + TTL + suppress loopback. */
+            if (dest_family == AF_INET) {
+                struct ip_mreqn mreq;
+                memset(&mreq, 0, sizeof(mreq));
+                mreq.imr_ifindex = ifindex;
+                if (setsockopt(data_sock, IPPROTO_IP, IP_MULTICAST_IF,
+                               &mreq, sizeof(mreq)) < 0) {
+                    perror("setsockopt(IP_MULTICAST_IF)");
+                }
+                int ttl = 16;
+                setsockopt(data_sock, IPPROTO_IP, IP_MULTICAST_TTL,
+                           &ttl, sizeof(ttl));
+                int loop = 0;
+                setsockopt(data_sock, IPPROTO_IP, IP_MULTICAST_LOOP,
+                           &loop, sizeof(loop));
+            } else {
+                if (setsockopt(data_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+                               &ifindex, sizeof(ifindex)) < 0) {
+                    perror("setsockopt(IPV6_MULTICAST_IF)");
+                }
+                int hops = 16;
+                setsockopt(data_sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
+                           &hops, sizeof(hops));
+                int loop = 0;
+                setsockopt(data_sock, IPPROTO_IPV6, IPV6_MULTICAST_LOOP,
+                           &loop, sizeof(loop));
+            }
+        }
+
+        /* Bind to ephemeral local port. Needed so recvfrom() on this
+         * socket picks up FEEDBACK replies. */
+        if (dest_family == AF_INET) {
+            struct sockaddr_in local = { .sin_family = AF_INET };
+            local.sin_addr.s_addr = htonl(INADDR_ANY);
+            local.sin_port = 0;
+            if (bind(data_sock, (struct sockaddr *)&local, sizeof(local)) < 0) {
+                perror("bind(udp v4)");
+                return 1;
+            }
+        } else {
+            struct sockaddr_in6 local = { .sin6_family = AF_INET6 };
+            local.sin6_addr = in6addr_any;
+            local.sin6_port = 0;
+            if (bind(data_sock, (struct sockaddr *)&local, sizeof(local)) < 0) {
+                perror("bind(udp v6)");
+                return 1;
+            }
+        }
+
+        int fl = fcntl(data_sock, F_GETFL, 0);
+        if (fl >= 0) fcntl(data_sock, F_SETFL, fl | O_NONBLOCK);
+
+        fb_sock = data_sock;   /* single-socket IP mode */
     }
-    struct sockaddr_ll fb_bind = {
-        .sll_family = AF_PACKET,
-        .sll_protocol = htons(AOE_C_ETHERTYPE),
-        .sll_ifindex = ifindex,
-    };
-    if (bind(fb_sock, (struct sockaddr *)&fb_bind, sizeof(fb_bind)) < 0) {
-        perror("bind(fb_sock)");
-        return 1;
-    }
-    int fl = fcntl(fb_sock, F_GETFL, 0);
-    if (fl >= 0) fcntl(fb_sock, F_SETFL, fl | O_NONBLOCK);
 
     int tfd = timerfd_create(CLOCK_MONOTONIC, 0);
     if (tfd < 0) { perror("timerfd_create"); return 1; }
@@ -268,31 +440,69 @@ int main(int argc, char **argv)
     uint8_t *frame = calloc(1, max_frame);
     if (!frame) return 1;
 
-    struct ether_header *eth = (struct ether_header *)frame;
-    memcpy(eth->ether_dhost, dest_mac, 6);
-    memcpy(eth->ether_shost, src_mac, 6);
-    eth->ether_type = htons(AOE_ETHERTYPE);
-
+    /* L2-only prefix (filled lazily and ignored in IP mode). */
+    if (transport == TRANSPORT_L2) {
+        struct ether_header *eth = (struct ether_header *)frame;
+        memcpy(eth->ether_dhost, dest_mac, 6);
+        memcpy(eth->ether_shost, src_mac, 6);
+        eth->ether_type = htons(AOE_ETHERTYPE);
+    }
     struct aoe_hdr *hdr = (struct aoe_hdr *)(frame + sizeof(struct ether_header));
     uint8_t *payload = frame + sizeof(struct ether_header) + AOE_HDR_LEN;
+    /* IP mode skips the 14-byte Ethernet-header prefix on the wire. */
+    const size_t tx_offset = (transport == TRANSPORT_L2) ? 0 : sizeof(struct ether_header);
 
-    fprintf(stderr,
-            "talker: iface=%s ifindex=%d\n"
-            "        src=%02x:%02x:%02x:%02x:%02x:%02x dst=%02x:%02x:%02x:%02x:%02x:%02x\n"
-            "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_frame=%zuB feedback=on\n",
-            iface, ifindex,
-            src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
-            dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
-            channels, rate_hz, nominal_spm, max_samples_per_packet, max_frame);
+    if (transport == TRANSPORT_L2) {
+        fprintf(stderr,
+                "talker: transport=l2 iface=%s ifindex=%d\n"
+                "        src=%02x:%02x:%02x:%02x:%02x:%02x dst=%02x:%02x:%02x:%02x:%02x:%02x\n"
+                "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_frame=%zuB feedback=on\n",
+                iface, ifindex,
+                src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
+                dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
+                channels, rate_hz, nominal_spm, max_samples_per_packet, max_frame);
+    } else {
+        char ip_str[INET6_ADDRSTRLEN] = {0};
+        if (dest_family == AF_INET) {
+            inet_ntop(AF_INET,
+                      &((struct sockaddr_in *)&dest_ss)->sin_addr,
+                      ip_str, sizeof(ip_str));
+        } else {
+            inet_ntop(AF_INET6,
+                      &((struct sockaddr_in6 *)&dest_ss)->sin6_addr,
+                      ip_str, sizeof(ip_str));
+        }
+        fprintf(stderr,
+                "talker: transport=ip dest=%s:%d family=%s %s\n"
+                "        iface=%s ifindex=%d\n"
+                "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_payload=%zuB feedback=on\n",
+                ip_str, udp_port,
+                dest_family == AF_INET ? "v4" : "v6",
+                dest_is_multicast ? "multicast" : "unicast",
+                iface, ifindex, channels, rate_hz,
+                nominal_spm, max_samples_per_packet,
+                max_frame - sizeof(struct ether_header));
+    }
 
     /* Mode C talker state: current target samples-per-microframe, fractional
-     * accumulator, and bookkeeping for stale-feedback fallback. */
+     * accumulator. The effective rate is recomputed each tick from the
+     * per-source feedback tracker below, so multi-receiver multicast picks
+     * the slowest consumer to avoid xruns at any endpoint. */
     double samples_per_microframe = nominal_spm;
     double sample_accum = 0.0;
-    struct timespec last_fb_rx_ts = { 0, 0 };
-    int have_fb = 0;
-    uint16_t last_fb_seq = 0;
-    int have_fb_seq = 0;
+
+    /* Multi-source feedback tracking (IP mode). In L2 mode there's only
+     * one receiver so slot 0 is used exclusively. */
+#define MAX_FB_SOURCES 16
+    struct fb_source {
+        int in_use;
+        struct sockaddr_storage addr;  /* IP mode: sender addr; L2: unused */
+        socklen_t addrlen;
+        uint32_t last_q;               /* Q16.16 samples/ms */
+        uint16_t last_seq;
+        int have_seq;
+        struct timespec last_rx;
+    } fb_src[MAX_FB_SOURCES] = {0};
 
     uint32_t seq = 0;
     uint64_t late_wakeups = 0;
@@ -302,28 +512,31 @@ int main(int argc, char **argv)
         /* 1. Drain any pending feedback frames (non-blocking). */
         for (;;) {
             uint8_t fb_buf[128];
-            ssize_t fn = recv(fb_sock, fb_buf, sizeof(fb_buf), 0);
+            struct sockaddr_storage src_addr;
+            socklen_t src_addrlen = sizeof(src_addr);
+            ssize_t fn;
+            if (transport == TRANSPORT_L2) {
+                fn = recv(fb_sock, fb_buf, sizeof(fb_buf), 0);
+            } else {
+                fn = recvfrom(fb_sock, fb_buf, sizeof(fb_buf), 0,
+                              (struct sockaddr *)&src_addr, &src_addrlen);
+            }
             if (fn < 0) {
                 if (errno == EAGAIN || errno == EWOULDBLOCK) break;
                 if (errno == EINTR) continue;
                 perror("recv(fb)");
                 break;
             }
-            if ((size_t)fn < sizeof(struct ether_header) + AOE_C_HDR_LEN) continue;
-            const struct aoe_c_hdr *fh =
-                (const struct aoe_c_hdr *)(fb_buf + sizeof(struct ether_header));
+
+            /* Locate the AoE-C header. L2 has the Ethernet header in front;
+             * IP has just the UDP payload. */
+            const struct aoe_c_hdr *fh;
+            size_t hdr_off = (transport == TRANSPORT_L2) ? sizeof(struct ether_header) : 0;
+            if ((size_t)fn < hdr_off + AOE_C_HDR_LEN) continue;
+            fh = (const struct aoe_c_hdr *)(fb_buf + hdr_off);
             if (!aoe_c_hdr_valid(fh)) continue;
             if (fh->frame_type != AOE_C_TYPE_FEEDBACK) continue;
             if (ntohs(fh->stream_id) != STREAM_ID) continue;
-
-            uint16_t s = ntohs(fh->sequence);
-            if (have_fb_seq) {
-                /* Reject stale (out-of-order) feedback to avoid rate whiplash. */
-                int16_t d = (int16_t)(s - last_fb_seq);
-                if (d <= 0) { fb_ignored++; continue; }
-            }
-            last_fb_seq = s;
-            have_fb_seq = 1;
 
             uint32_t q = ntohl(fh->value);
             double spms = (double)q / 65536.0;
@@ -336,20 +549,83 @@ int main(int argc, char **argv)
                 continue;
             }
 
-            samples_per_microframe = new_spm;
-            clock_gettime(CLOCK_MONOTONIC, &last_fb_rx_ts);
-            have_fb = 1;
+            /* Find or allocate a slot for this source. In L2 mode, every
+             * feedback comes from the single receiver — use slot 0. In IP
+             * mode, match by family + addr + port. */
+            int slot = -1;
+            if (transport == TRANSPORT_L2) {
+                slot = 0;
+                fb_src[0].in_use = 1;
+            } else {
+                for (int i = 0; i < MAX_FB_SOURCES; i++) {
+                    if (!fb_src[i].in_use) continue;
+                    if (fb_src[i].addr.ss_family != src_addr.ss_family) continue;
+                    int match = 0;
+                    if (src_addr.ss_family == AF_INET) {
+                        const struct sockaddr_in *a = (const struct sockaddr_in *)&fb_src[i].addr;
+                        const struct sockaddr_in *b = (const struct sockaddr_in *)&src_addr;
+                        match = (a->sin_port == b->sin_port) &&
+                                (a->sin_addr.s_addr == b->sin_addr.s_addr);
+                    } else {
+                        const struct sockaddr_in6 *a = (const struct sockaddr_in6 *)&fb_src[i].addr;
+                        const struct sockaddr_in6 *b = (const struct sockaddr_in6 *)&src_addr;
+                        match = (a->sin6_port == b->sin6_port) &&
+                                (memcmp(&a->sin6_addr, &b->sin6_addr, 16) == 0);
+                    }
+                    if (match) { slot = i; break; }
+                }
+                if (slot < 0) {
+                    for (int i = 0; i < MAX_FB_SOURCES; i++) {
+                        if (!fb_src[i].in_use) {
+                            slot = i;
+                            fb_src[i].in_use = 1;
+                            memcpy(&fb_src[i].addr, &src_addr, src_addrlen);
+                            fb_src[i].addrlen = src_addrlen;
+                            fb_src[i].have_seq = 0;
+                            break;
+                        }
+                    }
+                }
+                if (slot < 0) {
+                    /* Table full; drop. A real deployment would evict LRU;
+                     * for M4 with MAX=16 this is a soft upper bound. */
+                    fb_ignored++;
+                    continue;
+                }
+            }
+
+            /* Reject stale (out-of-order) feedback from the same source. */
+            uint16_t s16 = ntohs(fh->sequence);
+            if (fb_src[slot].have_seq) {
+                int16_t d = (int16_t)(s16 - fb_src[slot].last_seq);
+                if (d <= 0) { fb_ignored++; continue; }
+            }
+            fb_src[slot].last_seq = s16;
+            fb_src[slot].have_seq = 1;
+            fb_src[slot].last_q = q;
+            clock_gettime(CLOCK_MONOTONIC, &fb_src[slot].last_rx);
             fb_rx++;
         }
 
-        /* 2. Stale-feedback fallback: revert to nominal after FEEDBACK_STALE_MS. */
-        if (have_fb) {
-            struct timespec now;
-            clock_gettime(CLOCK_MONOTONIC, &now);
-            if (ts_diff_ms(now, last_fb_rx_ts) > FEEDBACK_STALE_MS) {
-                samples_per_microframe = nominal_spm;
-                have_fb = 0;
+        /* 2. Compute effective rate = min(q) across non-stale sources.
+         * Taking the slowest keeps every receiver from xrunning. */
+        struct timespec now_ts;
+        clock_gettime(CLOCK_MONOTONIC, &now_ts);
+        uint32_t min_q = 0;
+        int have_any = 0;
+        for (int i = 0; i < MAX_FB_SOURCES; i++) {
+            if (!fb_src[i].in_use) continue;
+            if (ts_diff_ms(now_ts, fb_src[i].last_rx) > FEEDBACK_STALE_MS) continue;
+            if (!have_any || fb_src[i].last_q < min_q) {
+                min_q = fb_src[i].last_q;
+                have_any = 1;
             }
+        }
+        if (have_any) {
+            double spms = (double)min_q / 65536.0;
+            samples_per_microframe = spms / (double)MICROFRAMES_PER_MS;
+        } else {
+            samples_per_microframe = nominal_spm;
         }
 
         /* 3. Wait for timer tick(s). */
@@ -362,8 +638,8 @@ int main(int argc, char **argv)
         }
         if (ticks > 1) late_wakeups++;
 
-        /* 4. Emit `ticks` packets. Each packet's payload_count is the integer
-         *    part of the accumulator; residual carries to the next packet. */
+        /* 4. Emit `ticks` packets. Each packet's payload_count is the
+         *    integer part of the accumulator; residual carries forward. */
         for (uint64_t i = 0; i < ticks && !g_stop; i++) {
             sample_accum += samples_per_microframe;
             int pc = (int)sample_accum;
@@ -379,12 +655,18 @@ int main(int argc, char **argv)
                           (uint8_t)channels, FORMAT_CODE, (uint8_t)pc,
                           AOE_FLAG_LAST_IN_GROUP);
 
-            size_t frame_len =
+            size_t frame_len_total =
                 sizeof(struct ether_header) + AOE_HDR_LEN
                 + (size_t)pc * channels * BYTES_PER_SAMPLE;
 
-            ssize_t sent = sendto(data_sock, frame, frame_len, 0,
-                                  (struct sockaddr *)&data_to, sizeof(data_to));
+            ssize_t sent;
+            if (transport == TRANSPORT_L2) {
+                sent = sendto(data_sock, frame, frame_len_total, 0,
+                              (struct sockaddr *)&data_to_ll, sizeof(data_to_ll));
+            } else {
+                sent = sendto(data_sock, frame + tx_offset, frame_len_total - tx_offset, 0,
+                              (struct sockaddr *)&dest_ss, dest_ss_len);
+            }
             if (sent < 0) {
                 if (errno == EINTR) break;
                 perror("sendto");
@@ -402,7 +684,7 @@ int main(int argc, char **argv)
 
     src->close(src);
     close(tfd);
-    close(fb_sock);
+    if (fb_sock != data_sock) close(fb_sock);
     close(data_sock);
     free(frame);
     return 0;


### PR DESCRIPTION
Implements Mode 3 (UDP over IP) from docs/wire-format.md alongside the existing Mode 1 (raw Ethernet). Both binaries gain a --transport l2|ip flag; L2 is the default and its behavior is unchanged. Talker adds --dest-ip (IPv4 or IPv6 literal) and --port; receiver adds --port and --group for multicast membership.

Scope choices:

Both address families. IPv6 is just a different sockaddr and a v6-scoped TCLASS/TTL setsockopt; nearly free to include alongside v4.

Both unicast and multicast. Multicast is the feature that makes IP mode actually useful for multi-zone audio. Auto-detected from the --dest-ip address range (224.0.0.0/4 for v4, ff00::/8 for v6). Talker sets IP_MULTICAST_IF, TTL, suppresses loopback. Receiver joins via IP_ADD_MEMBERSHIP / IPV6_JOIN_GROUP when --group is specified.

DSCP EF (0xB8) via IP_TOS / IPV6_TCLASS. Encourages WMM AC_VO on WiFi and priority queueing on DSCP-aware wired switches. Advisory.

Single-socket-per-side design for IP mode. Talker uses one UDP socket for TX data and RX feedback; receiver uses one for RX data and TX feedback. Magic byte (0xA0 vs 0xA1) disambiguates on the wire. Talker binds to ephemeral local port so receivers learn talker's (ip, port) from the source address of data datagrams and direct feedback back to the same socket.

Multi-receiver Mode C arbitration on the talker. A per-source tracker table (max 16 slots) holds the latest Q16.16 feedback value and timestamp per unique (IP, port). Each tick, effective samples_per_microframe is derived from the slowest non-stale source. This is the right default: under multicast, every receiver's DAC runs at its own crystal, and sending at the slowest rate keeps all receivers from xrunning. Sequence-number staleness is tracked per source too.

Documentation. docs/design.md M4 scope expanded to list the concrete deliverables; wire-format.md Mode 3 § updated to drop "M4+ future tense" and describe the feedback aggregation rule; README M4 row set to In progress. Per-dir READMEs document the new flags.

Known deferred from this pass: a recipe doc explicitly for WiFi / IP deployments. Add in a follow-up.