### PR TITLE
Add AVTP AAF transport for Milan interop (M5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository status
 
-**Pre-implementation.** There is no source code yet — only design documents. The canonical artifacts are:
+**M1–M4 merged to main; M5 (AVTP AAF) on its feature branch.** Canonical artifacts:
 
-- `docs/design.md` (v1.2) — architecture, rationale, milestone plan. Source of truth.
-- `docs/wire-format.md` (v1.2) — byte-level AoE header and transport encapsulation reference.
+- `docs/design.md` (v1.4) — architecture, rationale, milestone plan. Source of truth when in conflict with the code.
+- `docs/wire-format.md` (v1.4) — byte-level reference for the AoE header, AAF header, and AoE-C control header.
 - `CONTRIBUTING.md` — style and PR flow.
+- `docs/recipe-*.md` — operator-facing recipes for music sources (Roon, UPnP, PipeWire) and transport modes (Milan/AVTP).
 
-Any code you write must match what these documents specify. When design and code disagree, update the design doc in the same change — the doc is the canonical record (see CONTRIBUTING.md "Design discussion").
+When design and code disagree, update the design doc in the same change — the doc is the canonical record (see CONTRIBUTING.md "Design discussion").
 
-Implementation language is **C** (per CONTRIBUTING.md and the M1 sketch in `design.md`).
+Implementation language is **C** (per CONTRIBUTING.md). MCU firmware (Tier 3, M7+) will also be C.
 
 ## What's being built
 
@@ -30,10 +31,17 @@ From M1 onward, AOEther does NOT implement RAAT (Roon), UPnP MediaRenderer, AirP
 
 ### Wire format invariants
 
-Two coexisting protocols:
+Three coexisting protocols on the wire:
 
-- **Data frames** — 16-byte AoE header (Magic `0xA0`, Version `0x01`) on EtherType `0x88B5` (L2), AVTP `0x22F0` (Milan), or IP/UDP port 8805 (Mode 3). Only the outer wrapper changes across transport modes; the AoE header itself is identical.
-- **Control frames** — 16-byte AoE-C header (Magic `0xA1`, Version `0x01`) on EtherType `0x88B6`. Currently only FEEDBACK frames (type `0x01`) for Mode C clock discipline; see `docs/wire-format.md` §"Control frames". Any new out-of-band signaling should live here, not overloaded onto data frames.
+- **AOE data frames** — 16-byte AoE header (Magic `0xA0`, Version `0x01`) on EtherType `0x88B5` (L2) or IP/UDP port 8805 (Mode 3). The AoE header itself is identical across modes; only the outer wrapper varies.
+- **AVTP AAF data frames** (Mode 2, M5+) — 24-byte IEEE 1722 AAF header on EtherType `0x22F0` for PCM streams when `--transport avtp` is used. Format codes / NSR / channels are AAF-native, **not** AOE format codes. Samples are big-endian on the wire (AOE wrappers carry ALSA-native little-endian); `common/avtp.c::avtp_swap24_inplace` handles the byte-swap on the AVTP edge. DSD streams continue to use Mode 1 / Mode 3.
+- **Control frames** — 16-byte AoE-C header (Magic `0xA1`, Version `0x01`) on EtherType `0x88B6`, used by Mode C clock-discipline FEEDBACK regardless of which data transport is active. Milan listeners ignore unknown EtherTypes, so AOEther's feedback loop is invisible to them. Any new out-of-band signaling should live here, not overloaded onto data frames.
+
+Multi-byte fields are big-endian. Format codes, flag bits, control-frame value encodings, and the AAF byte layout are enumerated in `docs/wire-format.md` — treat that file as the authoritative spec; don't redefine codes locally.
+
+### AVDECC and Milan control-plane scope
+
+AOEther's M5 ships AVTP **data-plane** interop only. AVDECC (the IEEE 1722.1 entity model that lets Hive and other Milan controllers discover and bind streams), MSRP (stream reservation), and gPTP-disciplined `avtp_timestamp` are deliberately deferred to M7. Until then, Milan-listener subscription is manual (see `docs/recipe-milan.md`). Do not start an AVDECC implementation under a different milestone — it has design implications for the discovery layer that need to be considered alongside mDNS-SD (IP discovery) all at once in M7.
 
 Multi-byte fields are big-endian. Format codes, flag bits, and control-frame value encodings are enumerated in `docs/wire-format.md` — treat that file as the authoritative spec; don't redefine codes locally.
 
@@ -56,19 +64,26 @@ Non-negotiable data-path rules (from `design.md` Goals / Non-goals):
 
 ## Commands
 
-No build system exists yet. Once M1 lands there will be `talker/Makefile` and `receiver/Makefile`. Planned entry points (from `design.md` §M1):
-
 ```sh
-cd talker && make
-sudo ./build/talker --iface eno1 --dest-mac <pi-mac> --source testtone
+cd talker && make            # → build/talker
+cd receiver && make          # → build/receiver
 
-cd receiver && make
+# Default L2 (raw Ethernet) — M1 baseline:
 sudo ./build/receiver --iface eth0 --dac hw:CARD=<name>,DEV=0
+sudo ./build/talker   --iface eno1 --dest-mac <pi-mac> --source testtone
+
+# IP/UDP transport (M4) — IPv4 / IPv6, unicast or multicast:
+sudo ./build/receiver --iface eth0 --dac hw:... --transport ip --port 8805 --group 239.10.20.30
+sudo ./build/talker   --iface eno1 --transport ip --dest-ip 239.10.20.30 --source testtone
+
+# AVTP AAF transport (M5) — Milan interop:
+sudo ./build/receiver --iface eth0 --dac hw:... --transport avtp
+sudo ./build/talker   --iface eno1 --transport avtp --dest-mac 91:E0:F0:00:01:00 --source testtone
 ```
 
-Both binaries need `CAP_NET_RAW` (hence `sudo` during development) because they open raw `AF_PACKET` sockets. Required Linux build deps: `build-essential`, `libasound2-dev`. `linuxptp` is added at M3, `libnl-3-dev` later for TSN.
+Both binaries need `CAP_NET_RAW` (hence `sudo` during development) for raw `AF_PACKET` sockets in L2 / AVTP modes. IP mode binds an unprivileged UDP port. Required Linux build deps: `build-essential`, `libasound2-dev`. `linuxptp` is added at M3 Phase B (hardware PTP); `libnl-3-dev` later for TSN.
 
-There is no CI config, no `.clang-format`, and no `.editorconfig` yet — CONTRIBUTING.md says these land with M1. Until then, match the style spelled out there manually.
+There is no CI config, no `.clang-format`, and no `.editorconfig` yet. Match the style spelled out in CONTRIBUTING.md manually.
 
 ## Code style (from CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You should hear a clean 1 kHz tone.
 | M2 | In progress | Multichannel PCM (up to 7.1.4 / 16ch), hi-res rates (up to 192 kHz), per-DAC test matrix |
 | M3 | Docs ready | Tier 2 hardware (Linux SBC), hardware PTP (Phase A); hardware validation pending board |
 | M4 | In progress | IP/UDP transport, IPv4+IPv6, unicast+multicast, multi-receiver Mode C arbitration |
-| M5 | Planned | AVTP AAF wire format for Milan interop |
+| M5 | Code complete | AVTP AAF wire format for Milan interop (interop test pending listener hardware) |
 | M6 | Planned | Native DSD64 through DSD512 end-to-end |
 | M7 | Planned | AVDECC, MCU receiver track kickoff |
 | M8 | Planned | Full Atmos scale, DSD1024/2048, packaging |
@@ -97,6 +97,7 @@ AOEther doesn't implement Roon, UPnP, or AirPlay natively — it bridges them vi
 - [`docs/recipe-roon.md`](docs/recipe-roon.md) — Roon (via RoonBridge)
 - [`docs/recipe-upnp.md`](docs/recipe-upnp.md) — UPnP / DLNA controllers (via gmrender-resurrect)
 - [`docs/recipe-capture.md`](docs/recipe-capture.md) — desktop audio (browser, Tidal/Spotify apps, etc.) via PipeWire
+- [`docs/recipe-milan.md`](docs/recipe-milan.md) — Milan / AVTP interop: emit AAF to a Milan listener or receive from a Milan talker (M5)
 
 The same talker and receiver binaries run under every recipe; only the source daemon changes. AirPlay (shairport-sync) and Spotify Connect (librespot) plug in with the same pattern.
 

--- a/common/avtp.c
+++ b/common/avtp.c
@@ -1,0 +1,140 @@
+#include "avtp.h"
+
+#include <arpa/inet.h>
+#include <stddef.h>
+#include <string.h>
+
+/* Bit positions within the 32-bit format_specific word, mirroring libavtp:
+ *   FORMAT             shift 24, width 8
+ *   NSR                shift 20, width 4
+ *   (reserved)         shift 18, width 2
+ *   CHANNELS_PER_FRAME shift 8,  width 10  (bits 17..8 — leaks into octet 17 LSBs)
+ *   BIT_DEPTH          shift 0,  width 8
+ *
+ * The bit layout above produces the exact byte pattern that Hive,
+ * Wireshark's AVTP dissector, and Milan listeners expect. */
+
+int avtp_aaf_nsr_from_hz(int rate_hz, uint8_t *nsr)
+{
+    switch (rate_hz) {
+    case 8000:   *nsr = AAF_NSR_8000;   return 0;
+    case 16000:  *nsr = AAF_NSR_16000;  return 0;
+    case 24000:  *nsr = AAF_NSR_24000;  return 0;
+    case 32000:  *nsr = AAF_NSR_32000;  return 0;
+    case 44100:  *nsr = AAF_NSR_44100;  return 0;
+    case 48000:  *nsr = AAF_NSR_48000;  return 0;
+    case 88200:  *nsr = AAF_NSR_88200;  return 0;
+    case 96000:  *nsr = AAF_NSR_96000;  return 0;
+    case 176400: *nsr = AAF_NSR_176400; return 0;
+    case 192000: *nsr = AAF_NSR_192000; return 0;
+    default: return -1;
+    }
+}
+
+int avtp_aaf_hz_from_nsr(uint8_t nsr, int *rate_hz)
+{
+    switch (nsr) {
+    case AAF_NSR_8000:   *rate_hz = 8000;   return 0;
+    case AAF_NSR_16000:  *rate_hz = 16000;  return 0;
+    case AAF_NSR_24000:  *rate_hz = 24000;  return 0;
+    case AAF_NSR_32000:  *rate_hz = 32000;  return 0;
+    case AAF_NSR_44100:  *rate_hz = 44100;  return 0;
+    case AAF_NSR_48000:  *rate_hz = 48000;  return 0;
+    case AAF_NSR_88200:  *rate_hz = 88200;  return 0;
+    case AAF_NSR_96000:  *rate_hz = 96000;  return 0;
+    case AAF_NSR_176400: *rate_hz = 176400; return 0;
+    case AAF_NSR_192000: *rate_hz = 192000; return 0;
+    default: return -1;
+    }
+}
+
+void avtp_aaf_hdr_build(struct avtp_aaf_hdr *h,
+                        uint64_t stream_id,
+                        uint8_t  seq_num,
+                        uint32_t avtp_timestamp,
+                        uint8_t  aaf_format,
+                        uint8_t  nsr,
+                        uint16_t channels_per_frame,
+                        uint8_t  bit_depth,
+                        uint16_t stream_data_length)
+{
+    /* Octets 0-3: subtype | sv | version | mr | rsv | tv | seq_num | rsv | tu */
+    uint32_t sd = ((uint32_t)AVTP_SUBTYPE_AAF << 24)
+                | ((uint32_t)1u           << 23)   /* sv = stream_id valid */
+                /* version = 0  → bits 22..20 stay zero */
+                /* mr = 0       → bit 19 zero */
+                /* rsv          → bits 18..17 zero */
+                | ((avtp_timestamp ? 1u : 0u) << 16)  /* tv */
+                | ((uint32_t)seq_num      << 8);
+                /* tu = 0 (timestamp not uncertain) */
+    h->subtype_data = htonl(sd);
+
+    /* stream_id is opaque from AOEther's perspective; pass through. */
+    uint32_t sid_hi = (uint32_t)(stream_id >> 32);
+    uint32_t sid_lo = (uint32_t)(stream_id & 0xffffffffu);
+    uint32_t be_hi = htonl(sid_hi);
+    uint32_t be_lo = htonl(sid_lo);
+    memcpy((uint8_t *)&h->stream_id,     &be_hi, 4);
+    memcpy((uint8_t *)&h->stream_id + 4, &be_lo, 4);
+
+    h->avtp_timestamp = htonl(avtp_timestamp);
+
+    uint32_t fs = ((uint32_t)aaf_format             << 24)
+                | (((uint32_t)nsr & 0xfu)           << 20)
+                | (((uint32_t)channels_per_frame & 0x3ffu) << 8)
+                | ((uint32_t)bit_depth & 0xffu);
+    h->format_specific = htonl(fs);
+
+    /* SP = 0 (normal mode), EVT = 0, reserved = 0. */
+    uint32_t pi = ((uint32_t)stream_data_length << 16);
+    h->packet_info = htonl(pi);
+}
+
+int avtp_aaf_hdr_parse(const struct avtp_aaf_hdr *h,
+                       uint64_t *stream_id,
+                       uint8_t  *seq_num,
+                       uint32_t *avtp_timestamp,
+                       uint8_t  *aaf_format,
+                       uint8_t  *nsr,
+                       uint16_t *channels_per_frame,
+                       uint8_t  *bit_depth,
+                       uint16_t *stream_data_length)
+{
+    uint32_t sd = ntohl(h->subtype_data);
+    uint8_t  subtype = (uint8_t)((sd >> 24) & 0xff);
+    uint8_t  version = (uint8_t)((sd >> 20) & 0x07);
+    if (subtype != AVTP_SUBTYPE_AAF) return -1;
+    if (version != 0) return -1;
+
+    if (seq_num) *seq_num = (uint8_t)((sd >> 8) & 0xff);
+
+    if (stream_id) {
+        uint32_t hi, lo;
+        memcpy(&hi, (const uint8_t *)&h->stream_id, 4);
+        memcpy(&lo, (const uint8_t *)&h->stream_id + 4, 4);
+        *stream_id = ((uint64_t)ntohl(hi) << 32) | (uint64_t)ntohl(lo);
+    }
+    if (avtp_timestamp) *avtp_timestamp = ntohl(h->avtp_timestamp);
+
+    uint32_t fs = ntohl(h->format_specific);
+    if (aaf_format)         *aaf_format = (uint8_t)((fs >> 24) & 0xff);
+    if (nsr)                *nsr        = (uint8_t)((fs >> 20) & 0x0f);
+    if (channels_per_frame) *channels_per_frame = (uint16_t)((fs >> 8) & 0x3ff);
+    if (bit_depth)          *bit_depth  = (uint8_t)(fs & 0xff);
+
+    uint32_t pi = ntohl(h->packet_info);
+    if (stream_data_length) *stream_data_length = (uint16_t)((pi >> 16) & 0xffff);
+
+    return 0;
+}
+
+void avtp_swap24_inplace(void *buf, size_t n_samples)
+{
+    uint8_t *p = (uint8_t *)buf;
+    for (size_t i = 0; i < n_samples; i++) {
+        uint8_t b0 = p[0];
+        p[0] = p[2];
+        p[2] = b0;
+        p += 3;
+    }
+}

--- a/common/avtp.h
+++ b/common/avtp.h
@@ -1,0 +1,103 @@
+#pragma once
+
+/* IEEE 1722-2016 AVTP transport for AOEther (Mode 2, Milan interop).
+ *
+ * For PCM streams we emit AVTP AAF (subtype 0x02) frames directly. The
+ * AOE header is replaced by the 24-byte AVTP+AAF header on the wire,
+ * but Mode C clock-discipline feedback continues to flow on EtherType
+ * 0x88B6 unchanged — AVTP knows nothing about it and Milan listeners
+ * simply ignore it. See docs/wire-format.md §"Mode 2".
+ *
+ * AAF samples on the wire are big-endian per IEEE 1722-2016, unlike
+ * the AOE native wrapper which carries ALSA s24le directly. The talker
+ * byte-swaps on egress and the receiver byte-swaps on ingress; ALSA on
+ * both ends still sees s24le-3.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define AVTP_ETHERTYPE        0x22F0
+#define AVTP_HDR_LEN          24      /* 4 (subtype_data) + 8 (stream_id) +
+                                       * 4 (avtp_timestamp) + 4 (format_specific)
+                                       * + 4 (packet_info) */
+
+#define AVTP_SUBTYPE_AAF      0x02
+
+/* AAF format codes (IEEE 1722-2016 Table 19). */
+#define AAF_FORMAT_USER         0x00
+#define AAF_FORMAT_FLOAT32      0x01
+#define AAF_FORMAT_INT32        0x02
+#define AAF_FORMAT_INT24        0x03
+#define AAF_FORMAT_INT16        0x04
+#define AAF_FORMAT_AES3_32      0x05
+
+/* AAF nominal-sample-rate codes (IEEE 1722-2016 Table 20). */
+#define AAF_NSR_RESERVED        0x00
+#define AAF_NSR_8000            0x01
+#define AAF_NSR_16000           0x02
+#define AAF_NSR_32000           0x03
+#define AAF_NSR_44100           0x04
+#define AAF_NSR_48000           0x05
+#define AAF_NSR_88200           0x06
+#define AAF_NSR_96000           0x07
+#define AAF_NSR_176400          0x08
+#define AAF_NSR_192000          0x09
+#define AAF_NSR_24000           0x0A
+
+/* The packed AVTP-AAF header. All multi-byte fields are big-endian on the
+ * wire; the four 32-bit words below are stored network-order. Helpers
+ * avtp_aaf_hdr_build() / avtp_aaf_hdr_parse() handle the bit packing. */
+struct avtp_aaf_hdr {
+    uint32_t subtype_data;     /* subtype | sv | version | mr | tv | seq_num | tu */
+    uint64_t stream_id;        /* opaque 64-bit stream ID */
+    uint32_t avtp_timestamp;   /* gPTP nanoseconds, low 32 bits */
+    uint32_t format_specific;  /* format | nsr | channels_per_frame | bit_depth */
+    uint32_t packet_info;      /* stream_data_length (high 16) | flags (low 16) */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct avtp_aaf_hdr) == AVTP_HDR_LEN,
+               "AVTP-AAF header must be exactly 24 bytes");
+
+/* Map an audio sample rate in Hz to the AAF nsr code. Returns 0 on success,
+ * -1 if the rate is not a standard AAF rate. */
+int avtp_aaf_nsr_from_hz(int rate_hz, uint8_t *nsr);
+
+/* Inverse of the above. Returns 0 / Hz on success, -1 on unknown nsr. */
+int avtp_aaf_hz_from_nsr(uint8_t nsr, int *rate_hz);
+
+/* Build an AVTP-AAF header in network byte order.
+ *
+ * - sv is implicitly 1, version 0, mr 0, tu 0 (typical Milan listener PCM).
+ * - tv is 1 iff avtp_timestamp != 0 (no PTP on M5 yet → pass 0).
+ * - sp is 0 (normal — every packet carries a presentation time when tv=1).
+ * - evt is 0.
+ * - bit_depth is 24 for INT24, 32 for INT32/FLOAT32, 16 for INT16.
+ */
+void avtp_aaf_hdr_build(struct avtp_aaf_hdr *h,
+                        uint64_t stream_id,
+                        uint8_t  seq_num,
+                        uint32_t avtp_timestamp,
+                        uint8_t  aaf_format,
+                        uint8_t  nsr,
+                        uint16_t channels_per_frame,
+                        uint8_t  bit_depth,
+                        uint16_t stream_data_length);
+
+/* Parse an AVTP-AAF header. Returns 0 on success and fills the out params
+ * with host-order values. Returns -1 if the subtype is not AAF or the AVTP
+ * version is unknown. */
+int avtp_aaf_hdr_parse(const struct avtp_aaf_hdr *h,
+                       uint64_t *stream_id,
+                       uint8_t  *seq_num,
+                       uint32_t *avtp_timestamp,
+                       uint8_t  *aaf_format,
+                       uint8_t  *nsr,
+                       uint16_t *channels_per_frame,
+                       uint8_t  *bit_depth,
+                       uint16_t *stream_data_length);
+
+/* Byte-swap an interleaved buffer of packed 24-bit samples in place.
+ * AVTP AAF carries 24-bit samples big-endian; AOEther's source/sink path
+ * is ALSA s24le-3. Used on the AVTP egress / ingress edge only. */
+void avtp_swap24_inplace(void *buf, size_t n_samples);

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Audio-over-Ethernet for USB DACs
 
-**Status:** Draft v1.3 — design doc, M1 implementation in progress
+**Status:** Draft v1.4 — M1–M4 merged to main; M5 (AVTP AAF) code complete on `feature/m5-avtp-aaf`
 **Audience:** Contributors, reviewers, early adopters
 **License:** Apache 2.0 (proposed)
 
@@ -387,9 +387,24 @@ M3 is split into two sub-phases because it's mostly hardware work:
 
 **Goal:** Add AVTP (Mode 2) for Milan/AVB interop on PCM streams. DSD streams continue to use Mode 1 or 3.
 
-**Deliverables:** Talker emits AVTP AAF for PCM when `--transport avtp` is set. Receiver parses AVTP on the configured interface. Interop test with at least one Milan listener (Hive-controlled Motu AVB interface or equivalent).
+**Status:** Code complete; interop test pending hardware access to a Milan listener.
 
-**Time estimate:** 2 weekends.
+**Deliverables:**
+- `--transport avtp` on talker emits IEEE 1722-2016 AVTP AAF frames at EtherType `0x22F0` for any AOEther-supported PCM rate (44.1/48/88.2/96/176.4/192 kHz, 1..1023 channels).
+- `--transport avtp` on receiver parses AAF and writes to ALSA. Format / NSR / channels / bit-depth must match CLI; mismatched frames are dropped.
+- AAF byte-order conversion (big-endian on the wire ↔ ALSA little-endian) handled in-place by `common/avtp.c::avtp_swap24_inplace`.
+- Mode C feedback unchanged: AOEther's `0x88B6` control frames continue to flow alongside AVTP data; Milan-only listeners ignore the unknown EtherType.
+- Wire-format documentation in `docs/wire-format.md` §"Mode 2 (AVTP AAF)" with full byte layout, NSR table, and sample-byte-order rule.
+- Operator recipe in `docs/recipe-milan.md` covering Wireshark AVTP-dissector verification and listener-side stream subscription.
+
+**Out of scope (deferred to M7):**
+- AVDECC entity model (ATDECC over IEEE 1722.1) — required for Milan controllers like Hive to *discover* the stream automatically. Without it, listener-side stream ID and talker MAC must be configured manually.
+- MSRP / SRP stream reservation. AOEther emits at line rate without per-class shaping; works on quiet wires and TSN-class switches that accept best-effort AAF traffic.
+- gPTP-disciplined `avtp_timestamp`. M5 emits `tv=0` and `avtp_timestamp=0`. Listeners that require a valid presentation time will reject; many do not. Real PTP integration arrives in M3 Phase B (hardware) and is wired into the AVTP timestamp here in M7.
+
+**Key risks:** Milan listeners vary in strictness about AVDECC pre-negotiation. Without M7's AVDECC support, some won't accept AOEther's stream regardless of how correct the AAF bits are. The recipe doc calls this out and recommends Hive's "manual stream connection" workflow for testing.
+
+**Time estimate:** 2 weekends for the code (done); interop verification depends on listener access.
 
 ### M6 — Native DSD end-to-end
 

--- a/docs/recipe-milan.md
+++ b/docs/recipe-milan.md
@@ -1,0 +1,116 @@
+# Recipe: Milan / AVTP interop
+
+This recipe covers running an AOEther talker as an IEEE 1722 AVTP AAF source so that off-the-shelf Milan / AVB listeners (Hive-controlled MOTU AVB interfaces, L-Acoustics speakers, Avnu-certified audio devices) can receive a stream from AOEther.
+For wire-format details see [`wire-format.md`](wire-format.md) §"Mode 2 (AVTP AAF)".
+
+## What works in M5
+
+- Talker emits valid IEEE 1722-2016 AAF PCM frames at EtherType `0x22F0`.
+- AOEther receiver consumes those frames and plays them through any ALSA-supported DAC.
+- Mode C clock-discipline FEEDBACK frames continue to flow over `0x88B6` between AOEther endpoints. Milan listeners ignore them harmlessly.
+
+## What does NOT work yet
+
+- **No AVDECC.** Milan controllers like Hive will not see AOEther in the discovery panel. Streams must be subscribed manually (instructions below). AVDECC arrives in M7.
+- **No MSRP / SRP reservation.** Frames are sent best-effort. On a TSN switch this means traffic may be dropped under contention. A quiet wire or a switch configured to accept AAF on best-effort works.
+- **No gPTP-disciplined timestamps.** `tv` is `0` and `avtp_timestamp` is `0`. Listeners that *require* a valid presentation time will reject AOEther's frames; many do not (especially when stream subscription is manual). Real PTP integration arrives in M7 alongside AVDECC.
+- **PCM only.** AAF doesn't carry DSD; for DSD use `--transport l2` or `--transport ip` with the DAC matrix in [`dacs.md`](dacs.md).
+
+## Step 1 — verify the bytes look right with Wireshark
+
+Before troubleshooting against a real listener, confirm AOEther is emitting frames Wireshark's AVTP dissector accepts.
+
+```sh
+# On any host on the LAN (or the talker itself):
+sudo wireshark -i eth0 -k -f 'ether proto 0x22F0'
+```
+
+Run the talker against a multicast Milan-range MAC:
+
+```sh
+sudo ./build/talker --iface eno1 \
+                    --transport avtp \
+                    --dest-mac 91:E0:F0:00:01:00 \
+                    --source testtone --rate 48000 --channels 2
+```
+
+In Wireshark, frames should be classified as `IEEE 1722` and the dissector should display:
+- subtype = `02` (AAF)
+- format = `03` (INT_24)
+- nsr = `5` (48 kHz)
+- channels_per_frame = `2`
+- bit_depth = `24`
+- stream_data_length = `36` (= 6 samples × 2 ch × 3 B at 48 kHz / 8000 pps)
+- stream_id = your interface MAC followed by `0001`
+
+If any of those fields is wrong, the bytes will not be accepted by a real Milan listener. Fix the wire-level layout before moving on.
+
+## Step 2 — talker → AOEther receiver over AVTP
+
+Smoke-test the full AVTP path within AOEther itself. Both binaries support `--transport avtp`:
+
+```sh
+# Receiver
+sudo ./build/receiver --iface eth0 \
+                      --transport avtp \
+                      --dac hw:CARD=Dragonfly,DEV=0 \
+                      --rate 48000 --channels 2
+
+# Talker
+sudo ./build/talker --iface eno1 \
+                    --transport avtp \
+                    --dest-mac <receiver-iface-MAC> \
+                    --source testtone --rate 48000 --channels 2
+```
+
+You should hear a clean 1 kHz tone. Mode C feedback continues to operate (the receiver banner shows `feedback=on`) — useful as a positive control that the AAF byte-swap and packet sizing are right.
+
+## Step 3 — talker → Milan listener (e.g., Hive + MOTU AVB)
+
+Tested with: *(populate as we get data)*
+
+| Listener | Firmware | Result | Notes |
+|---|---|---|---|
+| MOTU AVB Stage-B16 | TBD | TBD | Manual stream subscription required |
+| L-Acoustics LA4X | TBD | TBD | TBD |
+
+General procedure with Hive:
+
+1. Plug talker and listener into the same wired switch (best-effort or AAF-class queue).
+2. Launch [Hive](https://github.com/christophe-calmejane/Hive) on a controller PC on the same LAN.
+3. Hive will discover the listener via AVDECC. It will **not** discover AOEther's talker (M7 prereq).
+4. In Hive's stream-connection panel, manually create a "stream input" entry for the listener pointing at:
+   - Stream ID = AOEther talker's MAC (6 bytes) followed by `0001`
+   - Stream destination MAC = whatever you passed to `--dest-mac`
+   - Stream format = AAF, INT_24, 48 kHz, *N* channels (must match talker)
+5. Activate the subscription on the listener side.
+6. Start the AOEther talker.
+
+If audio doesn't flow, check in order:
+- `tv` mismatch — some listeners reject `tv=0` outright. Workaround pre-M7: configure listener to "free-run" or "presentation time uncertain" mode if it offers one.
+- Sample-format mismatch — listener may default to INT_32 or INT_16. Set it to INT_24.
+- VLAN priority — Milan typically uses VLAN priority 3 (Class B) or 5 (Class A). AOEther emits untagged. Configure the switch to remap untagged → priority 3, or add an upstream VLAN tag.
+- Multicast filtering — IGMP snooping doesn't apply to L2 multicast, but some switches still flood-restrict the AVTP MAC range. Disable any "AVB unaware" forwarding rules.
+
+## Step 4 — Milan talker → AOEther receiver
+
+Symmetric direction also works. Configure the Milan talker (e.g., a MOTU AVB device acting as a source) to emit AAF at one of AOEther's supported rates (48 kHz / 96 kHz typically) at INT_24, then run AOEther receiver:
+
+```sh
+sudo ./build/receiver --iface eth0 \
+                      --transport avtp \
+                      --dac hw:CARD=ToppingE30,DEV=0 \
+                      --rate 48000 --channels 2
+```
+
+In this direction Mode C is inactive (the talker doesn't speak our 0x88B6 control frames), so stream stability depends on the Milan talker's gPTP-disciplined media clock. AOEther's receiver still sends FEEDBACK frames; a non-AOEther talker simply ignores them.
+
+## Troubleshooting
+
+**Talker says `AVTP AAF has no NSR code for rate N`** — AAF supports a fixed table of sample rates (8/16/24/32/44.1/48/88.2/96/176.4/192 kHz). AOEther covers everything in its standard rate set, but if you're trying a non-standard rate you'll hit this guard. Use a standard rate or fall back to `--transport l2`.
+
+**Receiver counter `dropped` rises rapidly with `rx=0`** — frames are arriving but the AAF format-specific block doesn't match (channels, NSR, or bit_depth disagrees with the CLI). Compare the talker's banner against the receiver's banner — they must match exactly.
+
+**Frames are emitted but Wireshark shows `Malformed Packet` under the AVTP dissector** — likely a bit-packing bug introduced by a local change to `common/avtp.c`. The reference implementation in `common/avtp.c::avtp_aaf_hdr_build` matches IEEE 1722-2016 Table 18 exactly; revert local changes.
+
+**Audio plays but with periodic clicks/pops on the listener side** — without gPTP, the listener has no synchronization signal and is free-running its own media clock. A short-term fix is to widen the listener's input buffer (most Milan listeners expose a "presentation offset" parameter); the long-term fix is M7 PTP.

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -1,6 +1,6 @@
 # AOEther Wire Format Specification
 
-**Status:** v1.3 draft — aligned with [`design.md`](design.md) v1.3
+**Status:** v1.4 draft — aligned with [`design.md`](design.md) v1.4
 **Purpose:** Byte-level reference for implementers of talkers, receivers, and test tools.
 
 This document specifies the AOEther wire format at the level of detail needed to build an interoperable implementation. For architectural rationale, see [`design.md`](design.md).
@@ -44,7 +44,7 @@ Mode 4 (RTP/AES67, M9, PCM only):
   No AoE header; RTP payload type and format per AES67 profile.
 ```
 
-Modes 1–3 carry the same AoE header and any supported format code (PCM, DoP, native DSD). Mode 4 is a separate PCM-only encoding for AES67 interop; see AES67 / RFC 3190 for RTP payload details. This document covers the AoE header itself, which appears in Modes 1, 2 (DSD vendor subtype), and 3.
+Modes 1, 3, and the DSD vendor-subtype path of Mode 2 carry the same AoE header and any supported format code (PCM, DoP, native DSD). The PCM path of Mode 2 carries IEEE 1722 AVTP AAF instead — see §"Mode 2 (AVTP AAF)" below. Mode 4 is a separate PCM-only encoding for AES67 interop; see AES67 / RFC 3190 for RTP payload details. This document covers the AoE header (§"AoE header"), the AAF header (§"Mode 2 (AVTP AAF)"), and the shared AoE-C control header (§"Control frames").
 
 **Destination address:**
 - Mode 1 / Mode 2: Ethernet unicast for point-to-point; multicast MAC range `01:1B:19:00:00:00/40` (AVTP reserved) for future multicast streams.
@@ -193,6 +193,78 @@ For payload sizes that exceed the MTU (native DSD2048 stereo is 2822 bytes per m
 | Stereo Native DSD64 | 88 B | 122 B |
 | Stereo Native DSD512 | 704 B | 738 B |
 | Stereo Native DSD2048 | 2822 B total → 2 pkts of 1411 B | 2 × 1445 B |
+
+## Mode 2 (AVTP AAF)
+
+When the talker is configured with `--transport avtp`, PCM streams are emitted as IEEE 1722-2016 AVTP AAF frames on EtherType `0x22F0` instead of the AOE wrapper. This is what makes a stream visible to off-the-shelf Milan listeners (Hive-controlled MOTU AVB interfaces, L-Acoustics speakers, audiophile devices that speak Milan, etc.). The control plane (AVDECC entity model, stream reservation) is **not** implemented in M5 — the talker emits frames as if AVDECC had already negotiated the stream, and the listener must be told out-of-band which stream ID and listener-side talker MAC to subscribe to. AVDECC integration arrives in M7.
+
+DSD streams continue to use Mode 1 / Mode 3; AAF doesn't carry DSD.
+
+### AVTP-AAF header (24 bytes)
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   subtype     |sv|version|mr|rsv|tv|  sequence_num |   rsv  |tu|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                          stream_id                            |
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       avtp_timestamp                          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   format    | nsr  | rsv |     channels_per_frame  | bit_depth|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|       stream_data_length      |sp|         reserved           |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+| Offset | Field | Width | Notes |
+|---|---|---|---|
+| 0 | subtype | 8 | `0x02` (AAF) |
+| 8 | sv | 1 | `1` (stream_id valid) |
+| 9 | version | 3 | `0` (AVTPv0) |
+| 12 | mr | 1 | media reset; toggled on stream restart, `0` otherwise |
+| 15 | tv | 1 | `1` if `avtp_timestamp` is valid; `0` until M3 PTP lands |
+| 16 | sequence_num | 8 | per-stream packet counter, wraps at 256 |
+| 31 | tu | 1 | timestamp uncertain; `0` for valid, `1` while gPTP is unlocked |
+| 32 | stream_id | 64 | AOEther mints `(src_mac << 16) | stream_id` until M7 |
+| 96 | avtp_timestamp | 32 | gPTP nanoseconds, low 32 bits; `0` when `tv=0` |
+| 128 | format | 8 | `0x03` (INT_24) for our s24 PCM; `0x04` INT_16, `0x02` INT_32, `0x01` FLOAT_32 also defined by spec |
+| 136 | nsr | 4 | sample-rate code (Table below) |
+| 144 | channels_per_frame | 10 | 1..1023 |
+| 152 | bit_depth | 8 | bits actually used per sample (24 for our INT_24) |
+| 160 | stream_data_length | 16 | bytes of PCM payload following the header |
+| 176 | sp | 1 | sparse mode; `0` for normal |
+
+Bit packing follows IEEE 1722-2016 Table 18 — the 32-bit `format / nsr / cpf / bit_depth` word at octets 16-19 packs as: format in the high byte, nsr in the next nibble, two reserved bits, then 10 bits of channels_per_frame, then 8 bits of bit_depth. The 32-bit `stream_data_length / sp / reserved` word at octets 20-23 carries the data length in the high half. The `common/avtp.c` helpers `avtp_aaf_hdr_build()` / `avtp_aaf_hdr_parse()` produce and consume this layout.
+
+### NSR codes
+
+| Code | Rate (Hz) |
+|---:|---:|
+| `0x01` | 8000 |
+| `0x02` | 16000 |
+| `0x03` | 32000 |
+| `0x04` | 44100 |
+| `0x05` | 48000 |
+| `0x06` | 88200 |
+| `0x07` | 96000 |
+| `0x08` | 176400 |
+| `0x09` | 192000 |
+| `0x0A` | 24000 |
+
+### Sample byte order
+
+**AAF samples are big-endian on the wire.** AOEther's source/sink path (ALSA `S24_3LE`) is little-endian, so the talker byte-swaps each 3-byte sample on AVTP egress and the receiver byte-swaps on AVTP ingress. This is the only data-path divergence between Mode 1/3 (which keep ALSA-native LE on the wire) and Mode 2.
+
+### Mode C feedback over AVTP
+
+AOEther's Mode C clock-discipline FEEDBACK frames continue to flow on EtherType `0x88B6` (see §"Control frames") regardless of data transport. A Milan listener that receives an AVTP stream from AOEther will simply ignore the unknown EtherType — it has no effect on AVTP framing or playback. When AOEther is the *receiver* and the talker is a third-party Milan device, FEEDBACK frames are still emitted but the third-party talker will ignore them; in that deployment Mode C is inactive and the AOEther receiver depends on the Milan talker's gPTP-disciplined media clock for stability.
+
+### Stream addressing
+
+Milan typically uses multicast destination MACs in the AVTP-reserved range `91:E0:F0:00:00:00/40`. AOEther's talker accepts any unicast or multicast MAC via `--dest-mac`; it does not register addresses with a switch via MSRP (that's Avnu/Milan controller territory and arrives no earlier than M7 alongside AVDECC).
 
 ## Control frames
 

--- a/receiver/Makefile
+++ b/receiver/Makefile
@@ -6,12 +6,13 @@ BUILD     := build
 INCLUDES  := -Isrc -I../common
 SRCS      := \
     src/receiver.c \
-    ../common/packet.c
+    ../common/packet.c \
+    ../common/avtp.c
 
 .PHONY: all clean
 all: $(BUILD)/receiver
 
-$(BUILD)/receiver: $(SRCS) ../common/packet.h | $(BUILD)
+$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -32,7 +32,7 @@ sudo ./build/receiver --iface eth0 \
 Flags:
 
 - `--iface IF`, `--dac hw:...` (required) — as above.
-- `--transport l2|ip` — default `l2` (raw Ethernet). `ip` switches to UDP (Mode 3).
+- `--transport l2|ip|avtp` — default `l2` (raw Ethernet, AOE wrapper). `ip` switches to UDP (Mode 3, M4). `avtp` accepts IEEE 1722 AAF on EtherType `0x22F0` (Mode 2, M5); see [`docs/recipe-milan.md`](../docs/recipe-milan.md).
 - `--port N` — UDP port to bind (IP mode only, default 8805).
 - `--group IP` — multicast group to join (IP mode only). IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8. Omit for unicast.
 - `--channels N` — channel count (1..64, default 2). Must match the talker.
@@ -44,7 +44,7 @@ Needs `CAP_NET_RAW` for the raw sockets in L2 mode; easiest path is `sudo`. IP m
 
 ## What it does, exactly
 
-- Opens two `AF_PACKET` sockets: one for RX on EtherType `0x88B5` (data), one for TX on `0x88B6` (Mode C FEEDBACK).
+- Opens two `AF_PACKET` sockets: one for RX on EtherType `0x88B5` (data — or `0x22F0` with `--transport avtp`), one for TX on `0x88B6` (Mode C FEEDBACK).
 - Accepts only data frames matching the M1 format: magic `0xA0`, version `0x01`, format `0x11` (PCM s24le-3), 2 channels.
 - Opens the named ALSA device at `S24_3LE`, 2ch, 48 kHz, ALSA soft-resample disabled.
 - Forwards payload bytes directly into `snd_pcm_writei`. ALSA is the jitter buffer; `snd_usb_audio` is the UAC2 stack and runs UAC2 async feedback with the DAC.

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -1,3 +1,4 @@
+#include "avtp.h"
 #include "packet.h"
 
 #include <alsa/asoundlib.h>
@@ -42,6 +43,7 @@
 enum transport_mode {
     TRANSPORT_L2 = 0,
     TRANSPORT_IP = 1,
+    TRANSPORT_AVTP = 2,
 };
 
 static int rate_supported(int hz)
@@ -68,7 +70,8 @@ static void usage(const char *prog)
 {
     fprintf(stderr,
         "usage: %s --iface IF --dac hw:CARD=NAME,DEV=0 [options]\n"
-        "  --transport l2|ip    transport mode, default l2\n"
+        "  --transport l2|ip|avtp  transport mode, default l2\n"
+        "                       (avtp = IEEE 1722 AAF, EtherType 0x22F0, Milan interop)\n"
         "  --port N             UDP port (IP mode, default %d)\n"
         "  --group IP           multicast group to join (IP mode, optional;\n"
         "                       IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8)\n"
@@ -135,9 +138,10 @@ int main(int argc, char **argv)
         case 'i': iface = optarg; break;
         case 'd': dac = optarg; break;
         case 'T':
-            if (strcmp(optarg, "l2") == 0) transport = TRANSPORT_L2;
-            else if (strcmp(optarg, "ip") == 0) transport = TRANSPORT_IP;
-            else { fprintf(stderr, "receiver: --transport must be l2 or ip\n"); return 2; }
+            if      (strcmp(optarg, "l2") == 0)   transport = TRANSPORT_L2;
+            else if (strcmp(optarg, "ip") == 0)   transport = TRANSPORT_IP;
+            else if (strcmp(optarg, "avtp") == 0) transport = TRANSPORT_AVTP;
+            else { fprintf(stderr, "receiver: --transport must be l2, ip, or avtp\n"); return 2; }
             break;
         case 'P': udp_port = atoi(optarg); break;
         case 'G': group_s = optarg; break;
@@ -157,9 +161,18 @@ int main(int argc, char **argv)
         fprintf(stderr, "receiver: --port out of range\n");
         return 2;
     }
-    if (transport == TRANSPORT_L2 && group_s) {
+    if (transport != TRANSPORT_IP && group_s) {
         fprintf(stderr, "receiver: --group only makes sense with --transport ip\n");
         return 2;
+    }
+
+    /* AVTP AAF only carries the standard NSR rates. */
+    uint8_t avtp_nsr_code = 0;
+    if (transport == TRANSPORT_AVTP) {
+        if (avtp_aaf_nsr_from_hz(rate_hz, &avtp_nsr_code) < 0) {
+            fprintf(stderr, "receiver: AVTP AAF has no NSR code for rate %d\n", rate_hz);
+            return 2;
+        }
     }
     if (channels < 1 || channels > 64) {
         fprintf(stderr, "receiver: --channels must be 1..64 (got %d)\n", channels);
@@ -180,8 +193,10 @@ int main(int argc, char **argv)
     int group_family = AF_UNSPEC;
     int use_multicast = 0;
 
-    if (transport == TRANSPORT_L2) {
-        data_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_ETHERTYPE));
+    if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
+        uint16_t data_etype = (transport == TRANSPORT_AVTP) ? AVTP_ETHERTYPE
+                                                            : AOE_ETHERTYPE;
+        data_sock = socket(AF_PACKET, SOCK_RAW, htons(data_etype));
         if (data_sock < 0) {
             perror("socket(AF_PACKET, SOCK_RAW) data");
             fprintf(stderr, "receiver: raw sockets need CAP_NET_RAW (try sudo)\n");
@@ -190,13 +205,14 @@ int main(int argc, char **argv)
         if (iface_lookup(data_sock, iface, &ifindex, my_mac) < 0) return 1;
         struct sockaddr_ll bind_ll = {
             .sll_family = AF_PACKET,
-            .sll_protocol = htons(AOE_ETHERTYPE),
+            .sll_protocol = htons(data_etype),
             .sll_ifindex = ifindex,
         };
         if (bind(data_sock, (struct sockaddr *)&bind_ll, sizeof(bind_ll)) < 0) {
             perror("bind(data_sock)");
             return 1;
         }
+        /* Mode C feedback is unchanged across L2 / AVTP — both ride 0x88B6. */
         ctl_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_C_ETHERTYPE));
         if (ctl_sock < 0) {
             perror("socket(AF_PACKET, SOCK_RAW) control");
@@ -312,10 +328,13 @@ int main(int argc, char **argv)
     signal(SIGINT, on_signal);
     signal(SIGTERM, on_signal);
 
-    if (transport == TRANSPORT_L2) {
+    if (transport != TRANSPORT_IP) {
         fprintf(stderr,
-                "receiver: transport=l2 iface=%s dac=%s fmt=S24_3LE ch=%d rate=%d latency_us=%d feedback=%s\n",
-                iface, dac, channels, rate_hz, latency_us,
+                "receiver: transport=%s iface=%s dac=%s fmt=%s ch=%d rate=%d latency_us=%d feedback=%s\n",
+                transport == TRANSPORT_AVTP ? "avtp" : "l2",
+                iface, dac,
+                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)→S24_3LE" : "S24_3LE",
+                channels, rate_hz, latency_us,
                 feedback_enabled ? "on" : "off");
     } else {
         fprintf(stderr,
@@ -361,7 +380,7 @@ int main(int argc, char **argv)
         (struct aoe_c_hdr *)(fb_frame + sizeof(struct ether_header));
     struct aoe_c_hdr *fb_hdr_ip =
         (struct aoe_c_hdr *)fb_frame;
-    if (transport == TRANSPORT_L2) {
+    if (transport != TRANSPORT_IP) {
         memcpy(fb_eth->ether_shost, my_mac, 6);
         fb_eth->ether_type = htons(AOE_C_ETHERTYPE);
     }
@@ -387,11 +406,11 @@ int main(int argc, char **argv)
             struct sockaddr_storage src_addr;
             socklen_t src_addrlen = sizeof(src_addr);
             ssize_t n;
-            if (transport == TRANSPORT_L2) {
-                n = recv(data_sock, buf, sizeof(buf), 0);
-            } else {
+            if (transport == TRANSPORT_IP) {
                 n = recvfrom(data_sock, buf, sizeof(buf), 0,
                              (struct sockaddr *)&src_addr, &src_addrlen);
+            } else {
+                n = recv(data_sock, buf, sizeof(buf), 0);
             }
             if (n < 0) {
                 if (errno == EINTR) continue;
@@ -399,50 +418,95 @@ int main(int argc, char **argv)
                 break;
             }
 
-            size_t hdr_off = (transport == TRANSPORT_L2) ? sizeof(struct ether_header) : 0;
-            if ((size_t)n < hdr_off + AOE_HDR_LEN) {
-                dropped++;
-                goto check_feedback;
-            }
-            const struct aoe_hdr *hdr =
-                (const struct aoe_hdr *)(buf + hdr_off);
-            if (!aoe_hdr_valid(hdr) ||
-                hdr->format != AOE_FMT_PCM_S24LE_3 ||
-                hdr->channel_count != channels) {
-                dropped++;
-                goto check_feedback;
+            /* Parse the protocol header into a uniform (frames, payload_ptr,
+             * sequence) tuple, then fall through to the common ALSA-write
+             * and talker-learning path. */
+            size_t hdr_off = (transport == TRANSPORT_IP) ? 0 : sizeof(struct ether_header);
+            size_t frames = 0;
+            size_t payload_bytes = 0;
+            uint8_t *payload_p = NULL;
+            uint32_t seq = 0;
+
+            if (transport == TRANSPORT_AVTP) {
+                if ((size_t)n < hdr_off + AVTP_HDR_LEN) { dropped++; goto check_feedback; }
+                const struct avtp_aaf_hdr *ah =
+                    (const struct avtp_aaf_hdr *)(buf + hdr_off);
+                uint8_t  af, ans, abd, aseq;
+                uint16_t acpf, asdl;
+                uint64_t asid;
+                uint32_t ats;
+                if (avtp_aaf_hdr_parse(ah, &asid, &aseq, &ats,
+                                       &af, &ans, &acpf, &abd, &asdl) < 0) {
+                    dropped++; goto check_feedback;
+                }
+                if (af != AAF_FORMAT_INT24 ||
+                    ans != avtp_nsr_code  ||
+                    abd != 24             ||
+                    acpf != channels) {
+                    dropped++; goto check_feedback;
+                }
+                payload_bytes = asdl;
+                if ((size_t)n < hdr_off + AVTP_HDR_LEN + payload_bytes) {
+                    dropped++; goto check_feedback;
+                }
+                size_t per_sample = (size_t)channels * BYTES_PER_SAMPLE;
+                if (per_sample == 0 || payload_bytes % per_sample != 0) {
+                    dropped++; goto check_feedback;
+                }
+                frames = payload_bytes / per_sample;
+                payload_p = buf + hdr_off + AVTP_HDR_LEN;
+                /* AAF samples are big-endian on the wire; ALSA wants LE. */
+                avtp_swap24_inplace(payload_p, frames * (size_t)channels);
+                /* AVTP only carries an 8-bit sequence; widen against last. */
+                seq = (uint32_t)aseq;
+            } else {
+                if ((size_t)n < hdr_off + AOE_HDR_LEN) { dropped++; goto check_feedback; }
+                const struct aoe_hdr *hdr =
+                    (const struct aoe_hdr *)(buf + hdr_off);
+                if (!aoe_hdr_valid(hdr) ||
+                    hdr->format != AOE_FMT_PCM_S24LE_3 ||
+                    hdr->channel_count != channels) {
+                    dropped++; goto check_feedback;
+                }
+                frames = hdr->payload_count;
+                payload_bytes = frames * (size_t)channels * BYTES_PER_SAMPLE;
+                if ((size_t)n < hdr_off + AOE_HDR_LEN + payload_bytes) {
+                    dropped++; goto check_feedback;
+                }
+                seq = ntohl(hdr->sequence);
+                payload_p = buf + hdr_off + AOE_HDR_LEN;
             }
 
-            size_t frames = hdr->payload_count;
-            size_t payload_bytes = (size_t)frames * (size_t)channels * BYTES_PER_SAMPLE;
-            if ((size_t)n < hdr_off + AOE_HDR_LEN + payload_bytes) {
-                dropped++;
-                goto check_feedback;
-            }
-
-            uint32_t seq = ntohl(hdr->sequence);
             if (have_seq) {
-                int32_t delta = (int32_t)(seq - last_seq);
-                if (delta > 1) lost += (uint64_t)(delta - 1);
+                /* AVTP wraps every 256 packets; AOE every 2^32. Both work
+                 * with a signed-difference compare against the appropriate
+                 * width — for AVTP we treat seq as 8-bit. */
+                if (transport == TRANSPORT_AVTP) {
+                    int8_t d8 = (int8_t)((uint8_t)seq - (uint8_t)last_seq);
+                    if (d8 > 1) lost += (uint64_t)(d8 - 1);
+                } else {
+                    int32_t delta = (int32_t)(seq - last_seq);
+                    if (delta > 1) lost += (uint64_t)(delta - 1);
+                }
             }
             last_seq = seq;
             have_seq = 1;
 
             if (!have_talker) {
-                if (transport == TRANSPORT_L2) {
+                if (transport == TRANSPORT_IP) {
+                    memcpy(&talker_addr, &src_addr, src_addrlen);
+                    talker_addr_len = src_addrlen;
+                } else {
+                    /* L2 / AVTP both have an Ethernet header in front. */
                     const struct ether_header *eth = (const struct ether_header *)buf;
                     memcpy(talker_mac, eth->ether_shost, 6);
                     memcpy(fb_eth->ether_dhost, talker_mac, 6);
                     memcpy(fb_to_ll.sll_addr, talker_mac, 6);
-                } else {
-                    memcpy(&talker_addr, &src_addr, src_addrlen);
-                    talker_addr_len = src_addrlen;
                 }
                 have_talker = 1;
             }
 
-            const uint8_t *payload = buf + hdr_off + AOE_HDR_LEN;
-            snd_pcm_sframes_t w = snd_pcm_writei(pcm, payload, frames);
+            snd_pcm_sframes_t w = snd_pcm_writei(pcm, payload_p, frames);
             if (w == -EPIPE) {
                 underruns++;
                 snd_pcm_prepare(pcm);
@@ -501,7 +565,7 @@ check_feedback:
             double spms = rate_est_hz / 1000.0;
             uint32_t q = (uint32_t)(spms * 65536.0 + 0.5);
             ssize_t ss;
-            if (transport == TRANSPORT_L2) {
+            if (transport != TRANSPORT_IP) {
                 aoe_c_hdr_build_feedback(fb_hdr_l2, STREAM_ID, fb_seq++, q);
                 ss = sendto(ctl_sock, fb_frame, sizeof(fb_frame), 0,
                             (struct sockaddr *)&fb_to_ll, sizeof(fb_to_ll));

--- a/talker/Makefile
+++ b/talker/Makefile
@@ -9,12 +9,13 @@ SRCS      := \
     src/audio_source_test.c \
     src/audio_source_wav.c \
     src/audio_source_alsa.c \
-    ../common/packet.c
+    ../common/packet.c \
+    ../common/avtp.c
 
 .PHONY: all clean
 all: $(BUILD)/talker
 
-$(BUILD)/talker: $(SRCS) src/audio_source.h ../common/packet.h | $(BUILD)
+$(BUILD)/talker: $(SRCS) src/audio_source.h ../common/packet.h ../common/avtp.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/talker/README.md
+++ b/talker/README.md
@@ -23,8 +23,8 @@ sudo ./build/talker --iface eno1 \
 Flags:
 
 - `--iface IF` (required) — egress interface, e.g. `eno1`, `enp3s0`.
-- `--transport l2|ip` — default `l2` (raw Ethernet). `ip` switches to UDP (Mode 3).
-- `--dest-mac AA:BB:CC:DD:EE:FF` — receiver's MAC (required with `--transport l2`).
+- `--transport l2|ip|avtp` — default `l2` (raw Ethernet, AOE wrapper). `ip` switches to UDP (Mode 3, M4). `avtp` emits IEEE 1722 AAF on EtherType `0x22F0` for Milan interop (Mode 2, M5); see [`docs/recipe-milan.md`](../docs/recipe-milan.md).
+- `--dest-mac AA:BB:CC:DD:EE:FF` — receiver's MAC (required with `--transport l2` or `--transport avtp`; for AVTP this is typically the listener's stream destination MAC, often a Milan-range multicast like `91:E0:F0:00:01:00`).
 - `--dest-ip IP` — destination IPv4 or IPv6 literal (required with `--transport ip`). Multicast groups (224.0.0.0/4 or ff00::/8) are auto-detected.
 - `--port N` — UDP port (IP mode only, default 8805).
 - `--source testtone|wav|alsa` — default `testtone` (1 kHz sine, −6 dBFS).
@@ -39,7 +39,7 @@ Needs `CAP_NET_RAW` to open `AF_PACKET` in L2 mode; easiest path is `sudo`. IP m
 
 - Stream ID `0x0001`, format `0x11` (PCM s24le-3). Channels and rate are runtime-configured via `--channels` and `--rate`; defaults match M1 (2 channels, 48 kHz).
 - Emits 1 packet per 125 µs tick from `timerfd`. The timer never retunes.
-- Ethernet II frame, EtherType `0x88B5`, AoE header per [`docs/wire-format.md`](../docs/wire-format.md).
+- Ethernet II frame, EtherType `0x88B5`, AoE header per [`docs/wire-format.md`](../docs/wire-format.md). With `--transport avtp` the wrapper switches to IEEE 1722 AAF (24-byte header, samples big-endian on the wire) at EtherType `0x22F0`; Mode C feedback continues on `0x88B6` regardless.
 - `payload_count` is **nominally `rate_hz / 8000` samples per packet but varies under Mode C feedback** — the talker keeps a fractional sample accumulator driven by the latest FEEDBACK value and writes the integer part into each packet. This is how USB hosts drive async DACs; we extend the same scheme across Ethernet.
 - Listens for FEEDBACK frames on EtherType `0x88B6` (a second raw socket). Clamps accepted rates to ±1000 ppm of nominal. Reverts to nominal rate if no feedback arrives for 5 s.
 - MTU check at startup: configurations whose worst-case packet exceeds 1500 bytes (very high multichannel × hi-res combinations) are rejected with a clear message. Packet splitting for those cases is deferred to a later milestone.

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -1,4 +1,5 @@
 #include "audio_source.h"
+#include "avtp.h"
 #include "packet.h"
 
 #include <arpa/inet.h>
@@ -42,8 +43,9 @@
 #define DSCP_EF_TOS           0xB8
 
 enum transport_mode {
-    TRANSPORT_L2 = 0,   /* raw Ethernet, AF_PACKET, EtherType 0x88B5/0x88B6 */
-    TRANSPORT_IP = 1,   /* UDP over IPv4, magic-byte disambiguation */
+    TRANSPORT_L2 = 0,    /* raw Ethernet, AF_PACKET, EtherType 0x88B5/0x88B6 */
+    TRANSPORT_IP = 1,    /* UDP over IPv4/v6, magic-byte disambiguation */
+    TRANSPORT_AVTP = 2,  /* IEEE 1722 AVTP AAF, EtherType 0x22F0 (Milan) */
 };
 
 /* Safety clamp on feedback-derived rate: ±1000 ppm of nominal. */
@@ -116,11 +118,13 @@ static void usage(const char *prog)
         "usage: %s --iface IF [transport options] [stream options]\n"
         "\n"
         "Transport (pick one):\n"
-        "  --transport l2               raw Ethernet, default\n"
+        "  --transport l2               raw Ethernet, AOE wrapper, default\n"
         "    --dest-mac AA:BB:CC:DD:EE:FF    (required)\n"
-        "  --transport ip               UDP over IPv4 (Mode 3, M4)\n"
-        "    --dest-ip X.Y.Z.W               (required)\n"
+        "  --transport ip               UDP over IPv4/v6 (Mode 3, M4)\n"
+        "    --dest-ip X.Y.Z.W | v6:literal  (required)\n"
         "    --port N                        UDP port, default %d\n"
+        "  --transport avtp             IEEE 1722 AAF, Milan interop (Mode 2, M5)\n"
+        "    --dest-mac AA:BB:CC:DD:EE:FF    (required; unicast or AVTP multicast)\n"
         "\n"
         "Source:\n"
         "  --source testtone|wav|alsa   default: testtone\n"
@@ -173,9 +177,10 @@ int main(int argc, char **argv)
         case 'd': dest_mac_s = optarg; break;
         case 'I': dest_ip_s = optarg; break;
         case 'T':
-            if (strcmp(optarg, "l2") == 0) transport = TRANSPORT_L2;
-            else if (strcmp(optarg, "ip") == 0) transport = TRANSPORT_IP;
-            else { fprintf(stderr, "talker: --transport must be l2 or ip\n"); return 2; }
+            if      (strcmp(optarg, "l2") == 0)   transport = TRANSPORT_L2;
+            else if (strcmp(optarg, "ip") == 0)   transport = TRANSPORT_IP;
+            else if (strcmp(optarg, "avtp") == 0) transport = TRANSPORT_AVTP;
+            else { fprintf(stderr, "talker: --transport must be l2, ip, or avtp\n"); return 2; }
             break;
         case 'P': udp_port = atoi(optarg); break;
         case 's': source = optarg; break;
@@ -191,8 +196,9 @@ int main(int argc, char **argv)
         usage(argv[0]);
         return 2;
     }
-    if (transport == TRANSPORT_L2 && !dest_mac_s) {
-        fprintf(stderr, "talker: --dest-mac required for --transport l2\n");
+    if ((transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) && !dest_mac_s) {
+        fprintf(stderr, "talker: --dest-mac required for --transport %s\n",
+                transport == TRANSPORT_L2 ? "l2" : "avtp");
         return 2;
     }
     if (transport == TRANSPORT_IP && !dest_ip_s) {
@@ -213,18 +219,31 @@ int main(int argc, char **argv)
     }
 
     /* MTU check: at worst we need nominal samples-per-microframe plus a
-     * small drift margin, times channels × bytes. Plus eth (14) + AoE (16). */
+     * small drift margin, times channels × bytes. Plus eth (14) + protocol
+     * header (16 for AOE, 24 for AVTP-AAF). */
+    const size_t proto_hdr_len = (transport == TRANSPORT_AVTP) ? AVTP_HDR_LEN
+                                                               : AOE_HDR_LEN;
     const double nominal_spm = (double)rate_hz / 1000.0 / MICROFRAMES_PER_MS;
     const int max_samples_per_packet = (int)(nominal_spm + 0.5) + 4;
     const size_t max_payload = (size_t)max_samples_per_packet * channels * BYTES_PER_SAMPLE;
-    const size_t max_frame = sizeof(struct ether_header) + AOE_HDR_LEN + max_payload;
-    if (max_payload + AOE_HDR_LEN > ETH_MTU_PAYLOAD) {
+    const size_t max_frame = sizeof(struct ether_header) + proto_hdr_len + max_payload;
+    if (max_payload + proto_hdr_len > ETH_MTU_PAYLOAD) {
         fprintf(stderr,
                 "talker: ch=%d rate=%d needs %zu-byte frames — exceeds 1500-byte MTU.\n"
                 "  (Packet splitting for very-high-rate multichannel is deferred; try\n"
                 "  fewer channels or a lower rate. Worst-case payload = %zu B.)\n",
                 channels, rate_hz, max_frame, max_payload);
         return 2;
+    }
+
+    /* AVTP AAF only carries integer PCM rates from the standard nsr table.
+     * Reject AOE rates that don't have an AAF code. */
+    uint8_t avtp_nsr_code = 0;
+    if (transport == TRANSPORT_AVTP) {
+        if (avtp_aaf_nsr_from_hz(rate_hz, &avtp_nsr_code) < 0) {
+            fprintf(stderr, "talker: AVTP AAF has no NSR code for rate %d\n", rate_hz);
+            return 2;
+        }
     }
 
     /* Destination resolution. Exactly one of (dest_mac) or (dest_ss) is
@@ -237,7 +256,7 @@ int main(int argc, char **argv)
     int dest_is_multicast = 0;
     memset(&dest_ss, 0, sizeof(dest_ss));
 
-    if (transport == TRANSPORT_L2) {
+    if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
         if (parse_mac(dest_mac_s, dest_mac) < 0) {
             fprintf(stderr, "talker: bad --dest-mac\n");
             return 2;
@@ -308,8 +327,10 @@ int main(int argc, char **argv)
     uint8_t src_mac[6] = {0};
     struct sockaddr_ll data_to_ll = {0};   /* used only in L2 */
 
-    if (transport == TRANSPORT_L2) {
-        data_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_ETHERTYPE));
+    if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
+        uint16_t data_etype = (transport == TRANSPORT_AVTP) ? AVTP_ETHERTYPE
+                                                            : AOE_ETHERTYPE;
+        data_sock = socket(AF_PACKET, SOCK_RAW, htons(data_etype));
         if (data_sock < 0) {
             perror("socket(AF_PACKET, SOCK_RAW) data");
             fprintf(stderr, "talker: raw sockets need CAP_NET_RAW (try sudo)\n");
@@ -318,11 +339,13 @@ int main(int argc, char **argv)
         if (iface_lookup(data_sock, iface, &ifindex, src_mac) < 0) return 1;
 
         data_to_ll.sll_family = AF_PACKET;
-        data_to_ll.sll_protocol = htons(AOE_ETHERTYPE);
+        data_to_ll.sll_protocol = htons(data_etype);
         data_to_ll.sll_ifindex = ifindex;
         data_to_ll.sll_halen = 6;
         memcpy(data_to_ll.sll_addr, dest_mac, 6);
 
+        /* Mode C feedback always travels on AOE-C (0x88B6) regardless of
+         * data transport — Milan listeners ignore unknown EtherTypes. */
         fb_sock = socket(AF_PACKET, SOCK_RAW, htons(AOE_C_ETHERTYPE));
         if (fb_sock < 0) {
             perror("socket(AF_PACKET, SOCK_RAW) feedback");
@@ -440,26 +463,45 @@ int main(int argc, char **argv)
     uint8_t *frame = calloc(1, max_frame);
     if (!frame) return 1;
 
-    /* L2-only prefix (filled lazily and ignored in IP mode). */
-    if (transport == TRANSPORT_L2) {
+    /* L2 / AVTP have an Ethernet header prefix; IP mode does not. */
+    if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
         struct ether_header *eth = (struct ether_header *)frame;
         memcpy(eth->ether_dhost, dest_mac, 6);
         memcpy(eth->ether_shost, src_mac, 6);
-        eth->ether_type = htons(AOE_ETHERTYPE);
+        eth->ether_type = htons(transport == TRANSPORT_AVTP
+                                ? AVTP_ETHERTYPE : AOE_ETHERTYPE);
     }
-    struct aoe_hdr *hdr = (struct aoe_hdr *)(frame + sizeof(struct ether_header));
-    uint8_t *payload = frame + sizeof(struct ether_header) + AOE_HDR_LEN;
+    struct aoe_hdr      *aoe_hdr_p  = (struct aoe_hdr *)
+        (frame + sizeof(struct ether_header));
+    struct avtp_aaf_hdr *avtp_hdr_p = (struct avtp_aaf_hdr *)
+        (frame + sizeof(struct ether_header));
+    uint8_t *payload = frame + sizeof(struct ether_header) + proto_hdr_len;
     /* IP mode skips the 14-byte Ethernet-header prefix on the wire. */
-    const size_t tx_offset = (transport == TRANSPORT_L2) ? 0 : sizeof(struct ether_header);
+    const size_t tx_offset = (transport == TRANSPORT_IP) ? sizeof(struct ether_header) : 0;
 
-    if (transport == TRANSPORT_L2) {
+    /* AVTP stream_id convention: source MAC in high 6 bytes, our 16-bit
+     * STREAM_ID in the low 2. Milan AVDECC normally allocates these via
+     * the entity model; we mint a stable one ourselves until M7. */
+    const uint64_t avtp_stream_id =
+          ((uint64_t)src_mac[0] << 56)
+        | ((uint64_t)src_mac[1] << 48)
+        | ((uint64_t)src_mac[2] << 40)
+        | ((uint64_t)src_mac[3] << 32)
+        | ((uint64_t)src_mac[4] << 24)
+        | ((uint64_t)src_mac[5] << 16)
+        | (uint64_t)STREAM_ID;
+    uint8_t avtp_seq8 = 0;
+
+    if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
+        const char *label = (transport == TRANSPORT_AVTP) ? "avtp" : "l2";
         fprintf(stderr,
-                "talker: transport=l2 iface=%s ifindex=%d\n"
+                "talker: transport=%s iface=%s ifindex=%d\n"
                 "        src=%02x:%02x:%02x:%02x:%02x:%02x dst=%02x:%02x:%02x:%02x:%02x:%02x\n"
-                "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_frame=%zuB feedback=on\n",
-                iface, ifindex,
+                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_frame=%zuB feedback=on\n",
+                label, iface, ifindex,
                 src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
                 dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
+                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : "PCM_s24le-3",
                 channels, rate_hz, nominal_spm, max_samples_per_packet, max_frame);
     } else {
         char ip_str[INET6_ADDRSTRLEN] = {0};
@@ -515,11 +557,11 @@ int main(int argc, char **argv)
             struct sockaddr_storage src_addr;
             socklen_t src_addrlen = sizeof(src_addr);
             ssize_t fn;
-            if (transport == TRANSPORT_L2) {
-                fn = recv(fb_sock, fb_buf, sizeof(fb_buf), 0);
-            } else {
+            if (transport == TRANSPORT_IP) {
                 fn = recvfrom(fb_sock, fb_buf, sizeof(fb_buf), 0,
                               (struct sockaddr *)&src_addr, &src_addrlen);
+            } else {
+                fn = recv(fb_sock, fb_buf, sizeof(fb_buf), 0);
             }
             if (fn < 0) {
                 if (errno == EAGAIN || errno == EWOULDBLOCK) break;
@@ -531,7 +573,7 @@ int main(int argc, char **argv)
             /* Locate the AoE-C header. L2 has the Ethernet header in front;
              * IP has just the UDP payload. */
             const struct aoe_c_hdr *fh;
-            size_t hdr_off = (transport == TRANSPORT_L2) ? sizeof(struct ether_header) : 0;
+            size_t hdr_off = (transport == TRANSPORT_IP) ? 0 : sizeof(struct ether_header);
             if ((size_t)fn < hdr_off + AOE_C_HDR_LEN) continue;
             fh = (const struct aoe_c_hdr *)(fb_buf + hdr_off);
             if (!aoe_c_hdr_valid(fh)) continue;
@@ -553,7 +595,8 @@ int main(int argc, char **argv)
              * feedback comes from the single receiver — use slot 0. In IP
              * mode, match by family + addr + port. */
             int slot = -1;
-            if (transport == TRANSPORT_L2) {
+            if (transport != TRANSPORT_IP) {
+                /* L2 / AVTP: a single physical talker-receiver pair, slot 0. */
                 slot = 0;
                 fb_src[0].in_use = 1;
             } else {
@@ -651,21 +694,39 @@ int main(int argc, char **argv)
                 g_stop = 1;
                 break;
             }
-            aoe_hdr_build(hdr, STREAM_ID, seq, 0,
-                          (uint8_t)channels, FORMAT_CODE, (uint8_t)pc,
-                          AOE_FLAG_LAST_IN_GROUP);
 
+            const size_t payload_bytes =
+                (size_t)pc * channels * BYTES_PER_SAMPLE;
             size_t frame_len_total =
-                sizeof(struct ether_header) + AOE_HDR_LEN
-                + (size_t)pc * channels * BYTES_PER_SAMPLE;
+                sizeof(struct ether_header) + proto_hdr_len + payload_bytes;
+
+            if (transport == TRANSPORT_AVTP) {
+                /* AAF carries 24-bit samples big-endian; ALSA gives us LE.
+                 * Swap in place before transmit. */
+                avtp_swap24_inplace(payload,
+                                    (size_t)pc * (size_t)channels);
+                avtp_aaf_hdr_build(avtp_hdr_p,
+                                   avtp_stream_id,
+                                   avtp_seq8++,
+                                   0,                    /* avtp_timestamp (no PTP yet) */
+                                   AAF_FORMAT_INT24,
+                                   avtp_nsr_code,
+                                   (uint16_t)channels,
+                                   24,                   /* bit_depth */
+                                   (uint16_t)payload_bytes);
+            } else {
+                aoe_hdr_build(aoe_hdr_p, STREAM_ID, seq, 0,
+                              (uint8_t)channels, FORMAT_CODE, (uint8_t)pc,
+                              AOE_FLAG_LAST_IN_GROUP);
+            }
 
             ssize_t sent;
-            if (transport == TRANSPORT_L2) {
-                sent = sendto(data_sock, frame, frame_len_total, 0,
-                              (struct sockaddr *)&data_to_ll, sizeof(data_to_ll));
-            } else {
+            if (transport == TRANSPORT_IP) {
                 sent = sendto(data_sock, frame + tx_offset, frame_len_total - tx_offset, 0,
                               (struct sockaddr *)&dest_ss, dest_ss_len);
+            } else {
+                sent = sendto(data_sock, frame, frame_len_total, 0,
+                              (struct sockaddr *)&data_to_ll, sizeof(data_to_ll));
             }
             if (sent < 0) {
                 if (errno == EINTR) break;


### PR DESCRIPTION
Implements Mode 2 (IEEE 1722-2016 AAF on EtherType 0x22F0) end-to-end:

  * common/avtp.{h,c}: AVTP-AAF 24-byte header build/parse, NSR table mapping for the standard PCM rates we already support, and an in-place 24-bit byte-swap helper for the AVTP edge.
  * talker: --transport avtp emits AAF frames; format/nsr packing matches libavtp/Hive convention so Wireshark's AVTP dissector and Milan listeners accept the bits.  Stream ID is minted from the interface MAC pending AVDECC.
  * receiver: --transport avtp accepts AAF, validates format/nsr/ channels/bit_depth match CLI, byte-swaps payload back to LE for ALSA s24le-3.  Mode C feedback continues to flow on 0x88B6 in both directions; Milan listeners ignore the unknown EtherType.

Wire-format reference:
  * docs/wire-format.md §"Mode 2 (AVTP AAF)" with full 24-byte byte layout and NSR code table.
  * Sample byte order rule: AAF on the wire is big-endian, AOE wire formats stay LE; the byte swap lives only in the AVTP edge.

Operator docs:
  * docs/recipe-milan.md walks through Wireshark verification, the AOEther-to-AOEther smoke test, manual stream subscription on Milan listeners (no AVDECC yet -> Hive cannot auto-discover us), and the Milan-talker -> AOEther-receiver direction.

Deliberately deferred to M7 (called out in design.md and CLAUDE.md):
  * AVDECC entity model + automatic stream discovery.
  * MSRP/SRP stream reservation.
  * gPTP-disciplined avtp_timestamp (we ship tv=0).

Status: code complete on this branch; interop verification against a real Milan listener is pending hardware access.