### PR TITLE
Add native DSD64-DSD512 end-to-end (M6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ From M1 onward, AOEther does NOT implement RAAT (Roon), UPnP MediaRenderer, AirP
 
 Three coexisting protocols on the wire:
 
-- **AOE data frames** — 16-byte AoE header (Magic `0xA0`, Version `0x01`) on EtherType `0x88B5` (L2) or IP/UDP port 8805 (Mode 3). The AoE header itself is identical across modes; only the outer wrapper varies.
+- **AOE data frames** — 16-byte AoE header (Magic `0xA0`, Version `0x01`) on EtherType `0x88B5` (L2) or IP/UDP port 8805 (Mode 3). The AoE header itself is identical across modes; only the outer wrapper varies. The `format` byte selects payload encoding: `0x11..0x13` PCM, `0x20..0x23` DoP-DSD (wire reserved, encoder not shipped yet), `0x30..0x33` native DSD64..512 (M6). Native DSD payload is MSB-first within each byte, interleaved across channels at **byte** granularity — matches `SND_PCM_FORMAT_DSD_U8` 1:1; other DSD_U* ALSA formats require a receiver-side transpose.
 - **AVTP AAF data frames** (Mode 2, M5+) — 24-byte IEEE 1722 AAF header on EtherType `0x22F0` for PCM streams when `--transport avtp` is used. Format codes / NSR / channels are AAF-native, **not** AOE format codes. Samples are big-endian on the wire (AOE wrappers carry ALSA-native little-endian); `common/avtp.c::avtp_swap24_inplace` handles the byte-swap on the AVTP edge. DSD streams continue to use Mode 1 / Mode 3.
 - **Control frames** — 16-byte AoE-C header (Magic `0xA1`, Version `0x01`) on EtherType `0x88B6`, used by Mode C clock-discipline FEEDBACK regardless of which data transport is active. Milan listeners ignore unknown EtherTypes, so AOEther's feedback loop is invisible to them. Any new out-of-band signaling should live here, not overloaded onto data frames.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You should hear a clean 1 kHz tone.
 | M3 | Docs ready | Tier 2 hardware (Linux SBC), hardware PTP (Phase A); hardware validation pending board |
 | M4 | In progress | IP/UDP transport, IPv4+IPv6, unicast+multicast, multi-receiver Mode C arbitration |
 | M5 | Code complete | AVTP AAF wire format for Milan interop (interop test pending listener hardware) |
-| M6 | Planned | Native DSD64 through DSD512 end-to-end |
+| M6 | Code complete | Native DSD64 through DSD512 end-to-end (silence smoke-test; DSD_U32_BE follow-up tracked) |
 | M7 | Planned | AVDECC, MCU receiver track kickoff |
 | M8 | Planned | Full Atmos scale, DSD1024/2048, packaging |
 | M9 | Planned | Ravenna / AES67 interop |
@@ -98,6 +98,7 @@ AOEther doesn't implement Roon, UPnP, or AirPlay natively — it bridges them vi
 - [`docs/recipe-upnp.md`](docs/recipe-upnp.md) — UPnP / DLNA controllers (via gmrender-resurrect)
 - [`docs/recipe-capture.md`](docs/recipe-capture.md) — desktop audio (browser, Tidal/Spotify apps, etc.) via PipeWire
 - [`docs/recipe-milan.md`](docs/recipe-milan.md) — Milan / AVTP interop: emit AAF to a Milan listener or receive from a Milan talker (M5)
+- [`docs/recipe-dsd.md`](docs/recipe-dsd.md) — native DSD64–DSD512 end-to-end (M6, silence smoke-test; real .dsf playback arrives in M8)
 
 The same talker and receiver binaries run under every recipe; only the source daemon changes. AirPlay (shairport-sync) and Spotify Connect (librespot) plug in with the same pattern.
 

--- a/common/packet.h
+++ b/common/packet.h
@@ -13,6 +13,30 @@
 #define AOE_FMT_PCM_S24LE_4      0x12
 #define AOE_FMT_PCM_S32LE        0x13
 
+/* DoP (DSD over PCM, RFC-style markers): payload is PCM s24le-3 at the
+ * inflated rate listed below; high byte alternates 0x05/0xFA. snd_usb_audio
+ * detects the marker pattern and switches the DAC into DSD mode. */
+#define AOE_FMT_DOP_DSD64        0x20   /* PCM s24le-3 @ 176.4 kHz */
+#define AOE_FMT_DOP_DSD128       0x21   /* PCM s24le-3 @ 352.8 kHz */
+#define AOE_FMT_DOP_DSD256       0x22   /* PCM s24le-3 @ 705.6 kHz */
+#define AOE_FMT_DOP_DSD512       0x23   /* PCM s24le-3 @ 1411.2 kHz */
+
+/* Native DSD: payload is the raw DSD bitstream, MSB-first within each byte,
+ * interleaved by channel. payload_count is bytes per channel in this packet
+ * (each byte = 8 DSD bits). DSD1024 / DSD2048 (codes 0x34/0x35) defined but
+ * deferred to M8. */
+#define AOE_FMT_NATIVE_DSD64     0x30   /* 2.8224 MHz/ch */
+#define AOE_FMT_NATIVE_DSD128    0x31   /* 5.6448 MHz/ch */
+#define AOE_FMT_NATIVE_DSD256    0x32   /* 11.2896 MHz/ch */
+#define AOE_FMT_NATIVE_DSD512    0x33   /* 22.5792 MHz/ch */
+#define AOE_FMT_NATIVE_DSD1024   0x34   /* 45.1584 MHz/ch (deferred to M8) */
+#define AOE_FMT_NATIVE_DSD2048   0x35   /* 90.3168 MHz/ch (deferred to M8) */
+
+/* DSD idle/silence pattern. Per Sony DSD spec, alternating-pulse DC zero is
+ * encoded as 01101001 (0x69) repeated. Some DACs prefer 0x96; both are
+ * acoustically silent. Used by talker's DSD silence source. */
+#define AOE_DSD_IDLE_BYTE        0x69
+
 #define AOE_FLAG_LAST_IN_GROUP   0x01
 #define AOE_FLAG_DISCONTINUITY   0x02
 #define AOE_FLAG_MARKER          0x04

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Audio-over-Ethernet for USB DACs
 
-**Status:** Draft v1.4 — M1–M4 merged to main; M5 (AVTP AAF) code complete on `feature/m5-avtp-aaf`
+**Status:** Draft v1.5 — M1–M4 merged to main; M5 (AVTP AAF) and M6 (native DSD64–DSD512) code complete on their feature branches
 **Audience:** Contributors, reviewers, early adopters
 **License:** Apache 2.0 (proposed)
 
@@ -410,11 +410,26 @@ M3 is split into two sub-phases because it's mostly hardware work:
 
 **Goal:** Native DSD64 through DSD512 working through the full pipeline. DoP as a selectable fallback.
 
-**Deliverables:** Wire format format-code parsing, ALSA native-DSD format selection on receiver, verified audio playback through a native-DSD-capable DAC (Topping D90, Holo May, RME ADI-2, etc.). DoP mode selectable when DAC prefers it. Works over L2 (Mode 1) and IP/UDP (Mode 3); AVTP does not carry DSD.
+**Status:** Wire-format and code paths complete; real-DAC listening test pending hardware access.
+
+**Deliverables:**
+- Format codes `0x30..0x33` (native DSD64/128/256/512) defined in `common/packet.h` and wired through talker and receiver.
+- Talker `--format dsd64|dsd128|dsd256|dsd512` switches payload semantics to DSD bytes/microframe (integer alternation around the non-integer target, e.g., 44/45 for DSD64) with no other plumbing changes — the same fractional accumulator that drives PCM payload_count also drives the DSD byte count, so Mode C works unmodified.
+- Talker built-in DSD silence source (`--source dsdsilence`, default when `--format` is DSD) emits the `0x69` idle pattern. Enough to verify the wire path and ALSA format selection end to end; real file playback comes in M8.
+- Receiver `--format dsd64..dsd512` opens ALSA at `SND_PCM_FORMAT_DSD_U8`. The wire format's per-byte channel interleaving and MSB-first bit order match DSD_U8 1:1, so no reorder is needed.
+- Mode C clock discipline continues to work under DSD rates (tested in code path; rate numbers are ~352.8..2822.4 samples/ms, outside UAC2 HS feedback legal range but AOEther treats the Q16.16 value as opaque rate telemetry).
+- Both L2 (Mode 1) and IP/UDP (Mode 3) transports carry DSD; AVTP (Mode 2) rejects DSD at startup per IEEE 1722 AAF's PCM-only scope.
+- Operator recipe in [`docs/recipe-dsd.md`](recipe-dsd.md) with smoke-test procedure, troubleshooting, and a clear statement of what's deferred.
+
+**Out of scope for M6 (tracked as follow-ups):**
+- `SND_PCM_FORMAT_DSD_U32_BE` / `_U16_LE` on the receiver. These formats require an N-byte-granularity channel interleave, i.e. a small transpose before `snd_pcm_writei`. Many DACs advertise only these formats via `snd_usb_audio` quirks — the follow-up unlocks those. Wire format is unchanged.
+- DoP encoder on the talker (format codes `0x20..0x23`). The wire format already reserves them; wiring up a PCM-wrapped-DSD source needs a small DoP modulator which is straightforward but didn't make M6's code budget.
+- DSF / DFF file reader. `.dsf` is simple (Sony spec, LSB-first per-byte bit order — inverse of our wire format, so a bit-reverse step is needed on read) but the per-DAC quirk testing it enables is better concentrated in M8 alongside DSD1024/2048.
+- DSD1024 / DSD2048. At DSD1024 stereo the per-microframe byte count exceeds MTU; packet splitting + `last-in-group` reassembly arrives in M8.
 
 **Key note:** This milestone is dramatically simpler than it was in earlier drafts because `snd_usb_audio` already does the hard work. Our code is about wire format and format selection, not kernel drivers.
 
-**Time estimate:** 2 weekends including real-DAC testing.
+**Time estimate:** 2 weekends for wire-format plumbing + silence-path smoke test (done). DAC-matrix build-out (M8 overlap) and U32_BE follow-up add incrementally.
 
 ### M7 — AVDECC, discovery, and MCU receiver track kickoff
 

--- a/docs/recipe-dsd.md
+++ b/docs/recipe-dsd.md
@@ -1,0 +1,104 @@
+# Recipe: native DSD end-to-end
+
+Native DSD transport via the AOE wrapper (Mode 1 / Mode 3). PCM and DoP paths are unchanged; this recipe focuses on what M6 adds.
+
+For the wire-format byte layout see [`wire-format.md`](wire-format.md) §"Native DSD".
+
+## What works in M6
+
+- Talker accepts `--format dsd64 | dsd128 | dsd256 | dsd512` and emits raw DSD bits on the wire with format codes `0x30..0x33`.
+- Receiver accepts the same `--format` values and opens ALSA at `SND_PCM_FORMAT_DSD_U8`, which is a 1:1 match for the wire format's per-byte channel interleaving and MSB-first bit order.
+- Mode C clock discipline works at DSD byte rates with no code change — the talker's fractional accumulator and the receiver's `snd_pcm_delay()`-based rate estimator are rate-independent.
+- Works over both L2 (`--transport l2`) and IP/UDP (`--transport ip`). AVTP (`--transport avtp`) does not carry DSD — AAF is PCM-only — and the talker and receiver both reject `avtp + dsd*` at startup.
+
+## What does NOT work yet
+
+- **Only `SND_PCM_FORMAT_DSD_U8`.** Many modern DACs advertise `SND_PCM_FORMAT_DSD_U32_BE` or `DSD_U16_LE` instead. These work fine with `snd_usb_audio` natively, but require a byte-reorder step in our receiver (4-byte- or 2-byte-granularity channel interleaving instead of 1-byte). That follow-up is tracked in the M6 PR.
+- **Only synthesized silence.** The talker's built-in `--source dsdsilence` emits the DSD idle pattern (`0x69`) on every channel. On a real DAC this plays as silence, which is exactly what's needed to verify the wire path and ALSA format selection work. Playing a real DSD file requires a `.dsf` / `.dff` reader (deferred to M8 alongside DSD1024/2048 — per-DAC quirk testing concentrates there).
+- **DoP mode is not wired up.** The wire format reserves codes `0x20..0x23` for DoP (PCM s24le-3 with 0x05 / 0xFA marker bytes at inflated rates), and talker/receiver framework would accept them, but the talker has no DoP encoder source yet. If a DAC works only through DoP and not native DSD, use PCM mode for now and wait for the DoP encoder.
+- **DSD1024 / DSD2048 require packet splitting.** At DSD1024 the per-microframe byte count exceeds 1500-byte MTU for stereo and the talker will refuse the configuration. M8 adds packet splitting and the `last-in-group` reassembly path.
+
+## Step 1 — smoke test: talker → receiver → DSD DAC
+
+Pick a rate your DAC supports natively. DSD64 and DSD128 are near-universal; DSD256 is common on modern DACs; DSD512 needs a specifically capable DAC.
+
+```sh
+# Receiver
+sudo ./build/receiver --iface eth0 \
+                      --dac hw:CARD=D90,DEV=0 \
+                      --format dsd64
+
+# Talker
+sudo ./build/talker --iface eno1 \
+                    --dest-mac <receiver-iface-MAC> \
+                    --format dsd64
+```
+
+Expected banner output on receiver:
+
+```
+receiver: transport=l2 iface=eth0 dac=hw:CARD=D90,DEV=0 fmt=dsd64 ch=2 rate=352800 latency_us=5000 feedback=on
+```
+
+Expected on talker:
+
+```
+talker: transport=l2 iface=eno1 ifindex=N
+        src=... dst=...
+        fmt=dsd64 ch=2 rate=352800 pps=8000 nominal_spp=44.10 max_spp=48 max_frame=...B feedback=on
+```
+
+On the DAC front panel / status LEDs you should see "DSD64" (or equivalent). Audible output is silence — that's correct for the `--source dsdsilence` synth source. What you're verifying:
+
+1. DAC indicator lights up as DSD (not PCM).
+2. `rx` counter on receiver rises at ~8000 per second.
+3. `fb_sent` counter on receiver rises (Mode C active; talker has locked onto the DAC clock).
+4. No xruns / underruns over a 5-minute run.
+
+## Step 2 — if the DAC rejects the stream
+
+The most common cause is the DAC not supporting `SND_PCM_FORMAT_DSD_U8`. Check what ALSA sees for your hardware:
+
+```sh
+cat /proc/asound/card0/pcm0p/sub0/hw_params  # while receiver is running
+# or:
+amixer -c 0 contents  # look for DSD format support
+```
+
+If `snd_usb_audio` quirks-table only exposes `DSD_U32_BE` or `DSD_U16_LE` for your DAC, AOEther's M6 `DSD_U8` path cannot drive it. Options:
+
+- Use PCM mode (`--format pcm --rate 192000`) and accept PCM output until the reorder follow-up lands.
+- Patch `receiver/src/receiver.c::parse_format` to select `SND_PCM_FORMAT_DSD_U32_BE` for your DAC **and** add a transpose-by-4 step before `snd_pcm_writei` (the in-PR follow-up covers this properly).
+
+## Step 3 — playing real DSD content
+
+Not supported in M6. The bridge-via-snd-aloop pattern used for PCM (`docs/recipe-roon.md`, `docs/recipe-capture.md`) won't work for DSD directly either, because `snd-aloop` is PCM-only.
+
+For now, the test workflow is silence-in / silence-out to verify protocol correctness. Real DSD playback arrives in M8 together with DSD1024/2048, a DSF file reader, and the per-DAC quirk matrix in [`dacs.md`](dacs.md).
+
+If you're impatient: HQPlayer's NAA remains the audiophile-grade path for DSD file playback today. AOEther's DSD differentiation is that it's open-source and the control plane can be extended (PTP, multichannel, AVDECC in M7).
+
+## Step 4 — DSD + IP/UDP
+
+The IP/UDP transport from M4 works transparently with DSD:
+
+```sh
+sudo ./build/receiver --iface eth0 --dac hw:... --transport ip --port 8805 --format dsd64
+sudo ./build/talker   --iface eno1 --transport ip --dest-ip 10.0.0.42 --format dsd64
+```
+
+Packet cadence and MTU behavior are the same as L2 — DSD64 stereo fits in ~90-byte frames regardless of transport. DSCP EF is still applied on egress.
+
+## Clock behavior under DSD
+
+Mode C feedback still applies and behaves identically to PCM: the receiver samples `snd_pcm_delay()` every 20 ms, differentiates `frames_written − delay` to estimate consumption rate, and emits Q16.16 samples-per-ms. Under DSD the Q16.16 value is the DSD byte rate / 1000 (e.g., ~352.8 for DSD64). This is outside the "UAC2 HS feedback" legal range but AOEther's talker treats it as an opaque rate target, not as UAC2 data. The ±1000 ppm safety clamp and the 5-second stale-feedback revert still apply.
+
+## Troubleshooting
+
+**Receiver: `snd_pcm_set_params (ch=2 rate=352800 fmt=dsd64): Invalid argument`** — DAC doesn't advertise DSD_U8. See Step 2 above.
+
+**Talker: `AVTP AAF does not carry DSD; use --transport l2 or ip with --format dsd*`** — correct; AAF is PCM-only. Switch transport.
+
+**Receiver: `dropped` counter rises with `rx=0`** — frames are arriving but the format code in the header doesn't match CLI. Make sure both talker and receiver use the same `--format`.
+
+**Receiver: `underruns` counter rises steadily** — DSD bandwidth at DSD512 stereo is ~22 Mbps; if the network or the DAC's USB path can't sustain that, underruns follow. Try a lower DSD rate or check for USB 2.0 hub contention (DSD512 requires a direct USB 2.0 HS connection, no hub in most cases).

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -1,6 +1,6 @@
 # AOEther Wire Format Specification
 
-**Status:** v1.4 draft — aligned with [`design.md`](design.md) v1.4
+**Status:** v1.5 draft — aligned with [`design.md`](design.md) v1.5
 **Purpose:** Byte-level reference for implementers of talkers, receivers, and test tools.
 
 This document specifies the AOEther wire format at the level of detail needed to build an interoperable implementation. For architectural rationale, see [`design.md`](design.md).
@@ -150,7 +150,17 @@ For configurations outside these standards, a channel map is advertised via the 
 
 ### Native DSD
 
-Payload is the raw DSD bitstream, interleaved by channel, MSB-first within each byte. Total payload length:
+Payload is the raw DSD bitstream, interleaved by channel **at byte granularity**, MSB-first within each byte. For a 2-channel DSD stream with `payload_count = N` the payload is:
+
+```
+L[0] R[0] L[1] R[1] ... L[N-1] R[N-1]
+```
+
+For `C` channels and `N` bytes per channel the payload is `C × N` bytes total, with per-byte round-robin interleave across channels. This matches `SND_PCM_FORMAT_DSD_U8` exactly, so a receiver using that ALSA format can pass the payload to `snd_pcm_writei` with no reorder. Receivers using `SND_PCM_FORMAT_DSD_U16_*` or `DSD_U32_*` MUST transpose at the corresponding granularity (2 or 4 bytes per channel) before writing.
+
+Bit order within each byte is MSB-first: the high bit of the byte is the older DSD sample, the low bit is the newer. This is opposite of the Sony DSF file format (which stores DSD LSB-first) — implementations ingesting DSF files must bit-reverse each byte on read.
+
+Total payload length:
 
 ```
 length = channel_count × payload_count

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -36,7 +36,8 @@ Flags:
 - `--port N` — UDP port to bind (IP mode only, default 8805).
 - `--group IP` — multicast group to join (IP mode only). IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8. Omit for unicast.
 - `--channels N` — channel count (1..64, default 2). Must match the talker.
-- `--rate HZ` — one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Must match the talker.
+- `--rate HZ` — PCM only: one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Must match the talker. Ignored for DSD — rate is implied by `--format`.
+- `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256 | dsd512` (M6). DSD uses `SND_PCM_FORMAT_DSD_U8`; DACs requiring `DSD_U32_BE` / `DSD_U16_LE` are a follow-up. See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
 - `--latency-us N` — ALSA period latency hint (default 5000 µs). Generous on purpose; the Mode C loop corrects ppm-scale drift slowly and the buffer also absorbs talker-side `timerfd` jitter.
 - `--no-feedback` — disable FEEDBACK emission. **Diagnostic only** — the positive control for the soak test (design.md §M1 test 7): with feedback off, the stream is expected to drift and xrun within minutes, confirming Mode C is doing real work when it's on.
 
@@ -45,8 +46,8 @@ Needs `CAP_NET_RAW` for the raw sockets in L2 mode; easiest path is `sudo`. IP m
 ## What it does, exactly
 
 - Opens two `AF_PACKET` sockets: one for RX on EtherType `0x88B5` (data — or `0x22F0` with `--transport avtp`), one for TX on `0x88B6` (Mode C FEEDBACK).
-- Accepts only data frames matching the M1 format: magic `0xA0`, version `0x01`, format `0x11` (PCM s24le-3), 2 channels.
-- Opens the named ALSA device at `S24_3LE`, 2ch, 48 kHz, ALSA soft-resample disabled.
+- Accepts only data frames whose format code matches `--format`: `0x11` (PCM s24le-3) for `--format pcm`, or `0x30..0x33` for `--format dsd64..dsd512`.
+- Opens the named ALSA device at the matching ALSA format (`S24_3LE` for PCM, `DSD_U8` for native DSD), with soft-resample disabled.
 - Forwards payload bytes directly into `snd_pcm_writei`. ALSA is the jitter buffer; `snd_usb_audio` is the UAC2 stack and runs UAC2 async feedback with the DAC.
 - On xrun (`EPIPE`) calls `snd_pcm_prepare`, re-seeds the rate estimator, and continues.
 - Tracks sequence-number gaps for loss reporting; no reorder buffer in M1.

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -20,11 +20,16 @@
 #include <time.h>
 #include <unistd.h>
 
-/* Stream format. Channels and rate are runtime-configured from M2 on; the
- * sample format is still locked to s24le-3 (other widths arrive later). See
- * docs/design.md §"M2" for the scope of what's parameterizable. */
+/* Stream format. Channels, rate, and sample format are all runtime-
+ * configured from M6 on. See docs/design.md §"M6" for the DSD path.
+ * "rate" generalizes to samples-or-DSD-bytes per sec per channel so the
+ * per-microframe math matches talker semantics. */
 #define STREAM_ID         0x0001
-#define BYTES_PER_SAMPLE  3
+
+#define DSD64_BYTE_RATE   352800
+#define DSD128_BYTE_RATE  705600
+#define DSD256_BYTE_RATE  1411200
+#define DSD512_BYTE_RATE  2822400
 
 /* Defaults match M1's previous hardcoded values. */
 #define DEFAULT_CHANNELS      2
@@ -58,6 +63,40 @@ static int rate_supported(int hz)
     }
 }
 
+struct stream_format {
+    uint8_t              wire_code;
+    int                  bytes_per_sample;
+    int                  rate_override;   /* >0 overrides --rate (DSD) */
+    snd_pcm_format_t     alsa_format;
+    int                  is_dsd;
+    const char          *name;
+};
+
+/* M6 ships DSD via SND_PCM_FORMAT_DSD_U8 only, which matches the wire-format
+ * byte order 1:1 (per-byte channel interleaving, MSB-first within each
+ * byte). DACs that require DSD_U16/U32 formats arrive in a follow-up with
+ * a reorder step. */
+static int parse_format(const char *s, struct stream_format *f)
+{
+    if (!s) return -1;
+    static const struct stream_format table[] = {
+        { AOE_FMT_PCM_S24LE_3,   3, 0,                SND_PCM_FORMAT_S24_3LE, 0, "pcm"    },
+        { AOE_FMT_NATIVE_DSD64,  1, DSD64_BYTE_RATE,  SND_PCM_FORMAT_DSD_U8,  1, "dsd64"  },
+        { AOE_FMT_NATIVE_DSD128, 1, DSD128_BYTE_RATE, SND_PCM_FORMAT_DSD_U8,  1, "dsd128" },
+        { AOE_FMT_NATIVE_DSD256, 1, DSD256_BYTE_RATE, SND_PCM_FORMAT_DSD_U8,  1, "dsd256" },
+        { AOE_FMT_NATIVE_DSD512, 1, DSD512_BYTE_RATE, SND_PCM_FORMAT_DSD_U8,  1, "dsd512" },
+    };
+    for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
+        if (strcmp(s, table[i].name) == 0) {
+            /* Re-assign the name pointer to the found table entry's literal
+             * so callers can keep using f->name safely. */
+            *f = table[i];
+            return 0;
+        }
+    }
+    return -1;
+}
+
 static volatile sig_atomic_t g_stop;
 
 static void on_signal(int sig)
@@ -75,9 +114,12 @@ static void usage(const char *prog)
         "  --port N             UDP port (IP mode, default %d)\n"
         "  --group IP           multicast group to join (IP mode, optional;\n"
         "                       IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8)\n"
+        "  --format FMT         pcm | dsd64 | dsd128 | dsd256 | dsd512\n"
+        "                       default pcm. AVTP transport is pcm-only.\n"
+        "                       DSD uses SND_PCM_FORMAT_DSD_U8 (per-DAC quirks apply).\n"
         "  --channels N         stream channel count (1..64, default %d)\n"
-        "  --rate HZ            44100 | 48000 | 88200 | 96000 | 176400 | 192000\n"
-        "                       (default %d)\n"
+        "  --rate HZ            PCM only: 44100|48000|88200|96000|176400|192000\n"
+        "                       (default %d; ignored for DSD — rate is implied by --format)\n"
         "  --latency-us N       ALSA period latency hint (default %d)\n"
         "  --no-feedback        do not emit Mode C FEEDBACK frames (diagnostic)\n",
         prog, DEFAULT_UDP_PORT, DEFAULT_CHANNELS, DEFAULT_RATE_HZ, DEFAULT_LATENCY_US);
@@ -112,6 +154,7 @@ int main(int argc, char **argv)
     const char *iface = NULL;
     const char *dac = NULL;
     const char *group_s = NULL;
+    const char *format_s = "pcm";
     int channels = DEFAULT_CHANNELS;
     int rate_hz = DEFAULT_RATE_HZ;
     int latency_us = DEFAULT_LATENCY_US;
@@ -127,13 +170,14 @@ int main(int argc, char **argv)
         { "group",       required_argument, 0, 'G' },
         { "channels",    required_argument, 0, 'C' },
         { "rate",        required_argument, 0, 'r' },
+        { "format",      required_argument, 0, 'F' },
         { "latency-us",  required_argument, 0, 'l' },
         { "no-feedback", no_argument,       0, 'n' },
         { "help",        no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:l:nh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:F:l:nh", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dac = optarg; break;
@@ -147,6 +191,7 @@ int main(int argc, char **argv)
         case 'G': group_s = optarg; break;
         case 'C': channels = atoi(optarg); break;
         case 'r': rate_hz = atoi(optarg); break;
+        case 'F': format_s = optarg; break;
         case 'l': latency_us = atoi(optarg); break;
         case 'n': feedback_enabled = 0; break;
         case 'h': usage(argv[0]); return 0;
@@ -166,6 +211,27 @@ int main(int argc, char **argv)
         return 2;
     }
 
+    if (channels < 1 || channels > 64) {
+        fprintf(stderr, "receiver: --channels must be 1..64 (got %d)\n", channels);
+        return 2;
+    }
+
+    struct stream_format fmt;
+    if (parse_format(format_s, &fmt) < 0) {
+        fprintf(stderr, "receiver: unknown --format %s\n", format_s);
+        return 2;
+    }
+    if (fmt.is_dsd) {
+        rate_hz = fmt.rate_override;
+    } else if (!rate_supported(rate_hz)) {
+        fprintf(stderr, "receiver: unsupported PCM --rate %d\n", rate_hz);
+        return 2;
+    }
+    if (transport == TRANSPORT_AVTP && fmt.is_dsd) {
+        fprintf(stderr, "receiver: AVTP AAF does not carry DSD; use --transport l2 or ip\n");
+        return 2;
+    }
+
     /* AVTP AAF only carries the standard NSR rates. */
     uint8_t avtp_nsr_code = 0;
     if (transport == TRANSPORT_AVTP) {
@@ -174,14 +240,8 @@ int main(int argc, char **argv)
             return 2;
         }
     }
-    if (channels < 1 || channels > 64) {
-        fprintf(stderr, "receiver: --channels must be 1..64 (got %d)\n", channels);
-        return 2;
-    }
-    if (!rate_supported(rate_hz)) {
-        fprintf(stderr, "receiver: unsupported --rate %d\n", rate_hz);
-        return 2;
-    }
+    const int bytes_per_sample = fmt.bytes_per_sample;
+    const uint8_t expected_format_code = fmt.wire_code;
 
     /* Socket setup per transport. L2 keeps two raw AF_PACKET sockets (one
      * per EtherType). IP uses one SOCK_DGRAM socket bound to udp_port —
@@ -310,7 +370,7 @@ int main(int argc, char **argv)
         return 1;
     }
     err = snd_pcm_set_params(pcm,
-                             SND_PCM_FORMAT_S24_3LE,
+                             fmt.alsa_format,
                              SND_PCM_ACCESS_RW_INTERLEAVED,
                              (unsigned int)channels,
                              (unsigned int)rate_hz,
@@ -318,10 +378,13 @@ int main(int argc, char **argv)
                              (unsigned int)latency_us);
     if (err < 0) {
         fprintf(stderr,
-                "snd_pcm_set_params (ch=%d rate=%d S24_3LE): %s\n"
+                "snd_pcm_set_params (ch=%d rate=%d fmt=%s): %s\n"
                 "  (DAC must natively support this configuration; "
-                "AOEther never resamples.)\n",
-                channels, rate_hz, snd_strerror(err));
+                "AOEther never resamples.  For DSD, check that the DAC's\n"
+                "  snd_usb_audio quirk exposes %s at this rate; some DACs\n"
+                "  require DSD_U32_BE instead, which is a follow-up.)\n",
+                channels, rate_hz, fmt.name, snd_strerror(err),
+                fmt.is_dsd ? "SND_PCM_FORMAT_DSD_U8" : "S24_3LE");
         return 1;
     }
 
@@ -333,19 +396,19 @@ int main(int argc, char **argv)
                 "receiver: transport=%s iface=%s dac=%s fmt=%s ch=%d rate=%d latency_us=%d feedback=%s\n",
                 transport == TRANSPORT_AVTP ? "avtp" : "l2",
                 iface, dac,
-                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)→S24_3LE" : "S24_3LE",
+                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)→S24_3LE" : fmt.name,
                 channels, rate_hz, latency_us,
                 feedback_enabled ? "on" : "off");
     } else {
         fprintf(stderr,
                 "receiver: transport=ip family=%s %s port=%d%s%s\n"
-                "          iface=%s dac=%s fmt=S24_3LE ch=%d rate=%d latency_us=%d feedback=%s\n",
+                "          iface=%s dac=%s fmt=%s ch=%d rate=%d latency_us=%d feedback=%s\n",
                 group_family == AF_INET6 ? "v6" : "v4",
                 use_multicast ? "multicast" : "unicast",
                 udp_port,
                 group_s ? " group=" : "",
                 group_s ? group_s : "",
-                iface, dac, channels, rate_hz, latency_us,
+                iface, dac, fmt.name, channels, rate_hz, latency_us,
                 feedback_enabled ? "on" : "off");
     }
 
@@ -449,7 +512,7 @@ int main(int argc, char **argv)
                 if ((size_t)n < hdr_off + AVTP_HDR_LEN + payload_bytes) {
                     dropped++; goto check_feedback;
                 }
-                size_t per_sample = (size_t)channels * BYTES_PER_SAMPLE;
+                size_t per_sample = (size_t)channels * bytes_per_sample;
                 if (per_sample == 0 || payload_bytes % per_sample != 0) {
                     dropped++; goto check_feedback;
                 }
@@ -464,12 +527,12 @@ int main(int argc, char **argv)
                 const struct aoe_hdr *hdr =
                     (const struct aoe_hdr *)(buf + hdr_off);
                 if (!aoe_hdr_valid(hdr) ||
-                    hdr->format != AOE_FMT_PCM_S24LE_3 ||
+                    hdr->format != expected_format_code ||
                     hdr->channel_count != channels) {
                     dropped++; goto check_feedback;
                 }
                 frames = hdr->payload_count;
-                payload_bytes = frames * (size_t)channels * BYTES_PER_SAMPLE;
+                payload_bytes = frames * (size_t)channels * bytes_per_sample;
                 if ((size_t)n < hdr_off + AOE_HDR_LEN + payload_bytes) {
                     dropped++; goto check_feedback;
                 }

--- a/talker/Makefile
+++ b/talker/Makefile
@@ -9,6 +9,7 @@ SRCS      := \
     src/audio_source_test.c \
     src/audio_source_wav.c \
     src/audio_source_alsa.c \
+    src/audio_source_dsd.c \
     ../common/packet.c \
     ../common/avtp.c
 

--- a/talker/README.md
+++ b/talker/README.md
@@ -27,17 +27,18 @@ Flags:
 - `--dest-mac AA:BB:CC:DD:EE:FF` — receiver's MAC (required with `--transport l2` or `--transport avtp`; for AVTP this is typically the listener's stream destination MAC, often a Milan-range multicast like `91:E0:F0:00:01:00`).
 - `--dest-ip IP` — destination IPv4 or IPv6 literal (required with `--transport ip`). Multicast groups (224.0.0.0/4 or ff00::/8) are auto-detected.
 - `--port N` — UDP port (IP mode only, default 8805).
-- `--source testtone|wav|alsa` — default `testtone` (1 kHz sine, −6 dBFS).
+- `--source testtone|wav|alsa|dsdsilence` — default `testtone` for PCM, `dsdsilence` for DSD. `testtone` is 1 kHz sine at −6 dBFS. `dsdsilence` emits the DSD idle pattern (`0x69`) — silent on a real DAC, used to verify the wire path.
 - `--file PATH` — WAV file when `--source wav`. Accepts PCM 24-bit at any of the supported channel counts and rates; the file loops.
 - `--capture hw:CARD=...` — ALSA PCM name when `--source alsa`. Point at one half of a `snd-aloop` pair to receive from Roon/UPnP/PipeWire; see `docs/recipe-*.md`.
 - `--channels N` — channel count (1..64, default 2). Receiver must match.
-- `--rate HZ` — one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Receiver must match.
+- `--rate HZ` — PCM only: one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Ignored for DSD — rate is implied by `--format`.
+- `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256 | dsd512` (M6). AVTP transport is PCM-only and rejects `dsd*` at startup. See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
 
 Needs `CAP_NET_RAW` to open `AF_PACKET` in L2 mode; easiest path is `sudo`. IP mode doesn't require root in principle (bind on ephemeral port is unprivileged), but if you want to bind to port 8805 < 1024 you'd need capabilities anyway — 8805 is fine without.
 
 ## What it does, exactly
 
-- Stream ID `0x0001`, format `0x11` (PCM s24le-3). Channels and rate are runtime-configured via `--channels` and `--rate`; defaults match M1 (2 channels, 48 kHz).
+- Stream ID `0x0001`. Format code is chosen by `--format`: `0x11` (PCM s24le-3, default), or `0x30..0x33` (native DSD64..DSD512, M6). Channels and rate are runtime-configured via `--channels` and `--rate`; defaults match M1 (2 channels, 48 kHz PCM).
 - Emits 1 packet per 125 µs tick from `timerfd`. The timer never retunes.
 - Ethernet II frame, EtherType `0x88B5`, AoE header per [`docs/wire-format.md`](../docs/wire-format.md). With `--transport avtp` the wrapper switches to IEEE 1722 AAF (24-byte header, samples big-endian on the wire) at EtherType `0x22F0`; Mode C feedback continues on `0x88B6` regardless.
 - `payload_count` is **nominally `rate_hz / 8000` samples per packet but varies under Mode C feedback** — the talker keeps a fractional sample accumulator driven by the latest FEEDBACK value and writes the integer part into each packet. This is how USB hosts drive async DACs; we extend the same scheme across Ethernet.

--- a/talker/src/audio_source.h
+++ b/talker/src/audio_source.h
@@ -14,3 +14,11 @@ struct audio_source {
 struct audio_source *audio_source_test_open(int channels, int rate, int bytes_per_sample);
 struct audio_source *audio_source_wav_open(const char *path);
 struct audio_source *audio_source_alsa_open(const char *pcm_name, int channels, int rate);
+
+/* DSD silence source (M6). `dsd_byte_rate` is bits/sec/channel ÷ 8; for
+ * DSD64 it's 352800, for DSD512 it's 2822400. `read()` returns the idle
+ * pattern (`AOE_DSD_IDLE_BYTE`) interleaved across channels — acoustically
+ * silent on a real DAC, but exercises the full wire-format and ALSA
+ * native-DSD path. A real DSF/DFF file reader is deferred to M8 alongside
+ * DSD1024/2048 because it ties into the same per-DAC-quirk matrix. */
+struct audio_source *audio_source_dsd_silence_open(int channels, int dsd_byte_rate);

--- a/talker/src/audio_source_dsd.c
+++ b/talker/src/audio_source_dsd.c
@@ -1,0 +1,55 @@
+#include "audio_source.h"
+#include "packet.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* M6 talker-side DSD source. Emits the standard DSD-idle pattern (0x69)
+ * interleaved across channels. On a real DSD-capable DAC this plays as
+ * silence, which is exactly what we want from a wire-path / format-code
+ * smoke test — anything else (a 1 kHz tone, modulated content) requires
+ * a real sigma-delta modulator or DSF file reader, both deferred. */
+
+struct dsd_state {
+    int channels;
+    int dsd_byte_rate;   /* bits/sec/channel ÷ 8 (e.g., 352800 for DSD64) */
+};
+
+static int dsd_read(struct audio_source *src, void *buf, size_t bytes_per_ch)
+{
+    struct dsd_state *st = src->opaque;
+    /* `bytes_per_ch` is the talker's payload_count for this packet; total
+     * bytes = bytes_per_ch × channels (interleaved by channel, MSB-first
+     * within each byte per the wire format). */
+    memset(buf, AOE_DSD_IDLE_BYTE, bytes_per_ch * (size_t)st->channels);
+    return 0;
+}
+
+static void dsd_close(struct audio_source *src)
+{
+    free(src->opaque);
+    free(src);
+}
+
+struct audio_source *audio_source_dsd_silence_open(int channels, int dsd_byte_rate)
+{
+    if (channels < 1 || dsd_byte_rate < 1) return NULL;
+
+    struct audio_source *src = calloc(1, sizeof(*src));
+    struct dsd_state    *st  = calloc(1, sizeof(*st));
+    if (!src || !st) {
+        free(src); free(st);
+        return NULL;
+    }
+    st->channels = channels;
+    st->dsd_byte_rate = dsd_byte_rate;
+    src->read = dsd_read;
+    src->close = dsd_close;
+    src->channels = channels;
+    src->rate = dsd_byte_rate;       /* "samples per sec per ch" semantic;
+                                      * here that's DSD bytes per sec per ch */
+    src->bytes_per_sample = 1;       /* one DSD byte per "sample" */
+    src->opaque = st;
+    return src;
+}

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -22,16 +22,22 @@
 #include <time.h>
 #include <unistd.h>
 
-/* Stream parameters. Channels and rate are runtime-configured from M2 on;
- * sample format is still locked to s24le-3. See docs/design.md §"M2". */
+/* Stream parameters. Channels, rate, and sample format are all runtime-
+ * configured from M6 on. The "rate" field generalizes to "samples or DSD-
+ * bytes per second per channel" so the per-microframe payload math (rate /
+ * 8000) works uniformly across PCM and native DSD. */
 #define STREAM_ID             0x0001
-#define BYTES_PER_SAMPLE      3
-#define FORMAT_CODE           AOE_FMT_PCM_S24LE_3
 #define PACKET_PERIOD_NS      125000L          /* 125 µs = 1 USB microframe */
 #define MICROFRAMES_PER_MS    8
 
 #define DEFAULT_CHANNELS      2
 #define DEFAULT_RATE_HZ       48000
+
+/* DSD byte rates per channel (DSD bit rate ÷ 8). */
+#define DSD64_BYTE_RATE       352800       /* 2.8224 MHz / 8 */
+#define DSD128_BYTE_RATE      705600
+#define DSD256_BYTE_RATE      1411200
+#define DSD512_BYTE_RATE      2822400
 
 /* Ethernet II data payload max (frame - eth header) for standard 1500 MTU. */
 #define ETH_MTU_PAYLOAD       1500
@@ -64,6 +70,37 @@ static int rate_supported(int hz)
     default:
         return 0;
     }
+}
+
+/* Map --format string to (AoE format code, bytes_per_sample, effective rate
+ * in samples-or-DSD-bytes per sec per channel). For PCM, the caller's
+ * --rate Hz is passed through; for DSD the rate is overridden to the DSD
+ * byte rate. Returns 0 on success, -1 if the name is unknown. */
+struct stream_format {
+    uint8_t  code;
+    int      bytes_per_sample;
+    int      rate_override;   /* >0 means override --rate; 0 means use --rate */
+    int      is_dsd;          /* native DSD path */
+    const char *name;
+};
+
+static int parse_format(const char *s, struct stream_format *f)
+{
+    if (!s) return -1;
+    static const struct stream_format table[] = {
+        { AOE_FMT_PCM_S24LE_3,    3, 0,                   0, "pcm"    },
+        { AOE_FMT_NATIVE_DSD64,   1, DSD64_BYTE_RATE,     1, "dsd64"  },
+        { AOE_FMT_NATIVE_DSD128,  1, DSD128_BYTE_RATE,    1, "dsd128" },
+        { AOE_FMT_NATIVE_DSD256,  1, DSD256_BYTE_RATE,    1, "dsd256" },
+        { AOE_FMT_NATIVE_DSD512,  1, DSD512_BYTE_RATE,    1, "dsd512" },
+    };
+    for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
+        if (strcmp(s, table[i].name) == 0) {
+            *f = table[i];
+            return 0;
+        }
+    }
+    return -1;
 }
 
 static volatile sig_atomic_t g_stop;
@@ -127,16 +164,22 @@ static void usage(const char *prog)
         "    --dest-mac AA:BB:CC:DD:EE:FF    (required; unicast or AVTP multicast)\n"
         "\n"
         "Source:\n"
-        "  --source testtone|wav|alsa   default: testtone\n"
+        "  --source testtone|wav|alsa|dsdsilence   default: testtone (pcm) /\n"
+        "                                          dsdsilence when --format is DSD\n"
         "  --file   PATH                WAV file, required with --source wav\n"
         "  --capture hw:CARD=...        ALSA capture device, required with --source alsa\n"
         "\n"
         "Stream format:\n"
+        "  --format  FMT                pcm | dsd64 | dsd128 | dsd256 | dsd512\n"
+        "                               default pcm. DoP and DSD1024+ are deferred.\n"
+        "                               AVTP transport carries pcm only.\n"
         "  --channels N                 channel count (1..64, default %d)\n"
         "  --rate    HZ                 44100|48000|88200|96000|176400|192000 (default %d)\n"
+        "                               (ignored for native DSD — rate is implied by --format)\n"
         "\n"
-        "Sample format is s24le-3 (24-bit little-endian packed). Sources must match\n"
-        "channels, rate, and format exactly — AOEther never resamples.\n"
+        "PCM payload is s24le-3 (24-bit little-endian packed). Native DSD payload is\n"
+        "raw DSD bits, MSB-first within each byte, interleaved by channel. Sources\n"
+        "must match channels, rate, and format exactly — AOEther never resamples.\n"
         "For music playback, point --capture at one half of a snd-aloop pair\n"
         "and route Roon/UPnP/AirPlay/PipeWire at the other half; see\n"
         "docs/recipe-*.md.\n",
@@ -148,9 +191,10 @@ int main(int argc, char **argv)
     const char *iface = NULL;
     const char *dest_mac_s = NULL;
     const char *dest_ip_s = NULL;
-    const char *source = "testtone";
+    const char *source = NULL;         /* default resolved below from --format */
     const char *wav_path = NULL;
     const char *capture_pcm = NULL;
+    const char *format_s = "pcm";
     int channels = DEFAULT_CHANNELS;
     int rate_hz = DEFAULT_RATE_HZ;
     enum transport_mode transport = TRANSPORT_L2;
@@ -167,11 +211,12 @@ int main(int argc, char **argv)
         { "capture",   required_argument, 0, 'c' },
         { "channels",  required_argument, 0, 'C' },
         { "rate",      required_argument, 0, 'r' },
+        { "format",    required_argument, 0, 'F' },
         { "help",      no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:I:T:P:s:f:c:C:r:h", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:I:T:P:s:f:c:C:r:F:h", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dest_mac_s = optarg; break;
@@ -188,6 +233,7 @@ int main(int argc, char **argv)
         case 'c': capture_pcm = optarg; break;
         case 'C': channels = atoi(optarg); break;
         case 'r': rate_hz = atoi(optarg); break;
+        case 'F': format_s = optarg; break;
         case 'h': usage(argv[0]); return 0;
         default:  usage(argv[0]); return 2;
         }
@@ -213,8 +259,37 @@ int main(int argc, char **argv)
         fprintf(stderr, "talker: --channels must be 1..64 (got %d)\n", channels);
         return 2;
     }
-    if (!rate_supported(rate_hz)) {
-        fprintf(stderr, "talker: unsupported --rate %d\n", rate_hz);
+
+    struct stream_format fmt;
+    if (parse_format(format_s, &fmt) < 0) {
+        fprintf(stderr, "talker: unknown --format %s\n", format_s);
+        return 2;
+    }
+    /* For PCM the user-supplied --rate applies; native DSD overrides. */
+    if (!fmt.is_dsd) {
+        if (!rate_supported(rate_hz)) {
+            fprintf(stderr, "talker: unsupported --rate %d for PCM\n", rate_hz);
+            return 2;
+        }
+    } else {
+        rate_hz = fmt.rate_override;
+    }
+    if (transport == TRANSPORT_AVTP && fmt.is_dsd) {
+        fprintf(stderr, "talker: AVTP AAF does not carry DSD; use --transport l2 or ip with --format dsd*\n");
+        return 2;
+    }
+    const uint8_t format_code = fmt.code;
+    const int bytes_per_sample = fmt.bytes_per_sample;
+    const int is_dsd = fmt.is_dsd;
+
+    /* Default source depends on format: testtone (PCM sine) or dsdsilence. */
+    if (!source) {
+        source = is_dsd ? "dsdsilence" : "testtone";
+    } else if (is_dsd && strcmp(source, "dsdsilence") != 0) {
+        fprintf(stderr, "talker: --source %s is PCM-only; native DSD requires --source dsdsilence (default)\n", source);
+        return 2;
+    } else if (!is_dsd && strcmp(source, "dsdsilence") == 0) {
+        fprintf(stderr, "talker: --source dsdsilence requires --format dsd64|128|256|512\n");
         return 2;
     }
 
@@ -225,7 +300,7 @@ int main(int argc, char **argv)
                                                                : AOE_HDR_LEN;
     const double nominal_spm = (double)rate_hz / 1000.0 / MICROFRAMES_PER_MS;
     const int max_samples_per_packet = (int)(nominal_spm + 0.5) + 4;
-    const size_t max_payload = (size_t)max_samples_per_packet * channels * BYTES_PER_SAMPLE;
+    const size_t max_payload = (size_t)max_samples_per_packet * channels * bytes_per_sample;
     const size_t max_frame = sizeof(struct ether_header) + proto_hdr_len + max_payload;
     if (max_payload + proto_hdr_len > ETH_MTU_PAYLOAD) {
         fprintf(stderr,
@@ -291,7 +366,7 @@ int main(int argc, char **argv)
 
     struct audio_source *src = NULL;
     if (strcmp(source, "testtone") == 0) {
-        src = audio_source_test_open(channels, rate_hz, BYTES_PER_SAMPLE);
+        src = audio_source_test_open(channels, rate_hz, bytes_per_sample);
     } else if (strcmp(source, "wav") == 0) {
         if (!wav_path) {
             fprintf(stderr, "talker: --file required with --source wav\n");
@@ -312,6 +387,8 @@ int main(int argc, char **argv)
             return 2;
         }
         src = audio_source_alsa_open(capture_pcm, channels, rate_hz);
+    } else if (strcmp(source, "dsdsilence") == 0) {
+        src = audio_source_dsd_silence_open(channels, rate_hz);
     } else {
         fprintf(stderr, "talker: unknown --source %s\n", source);
         return 2;
@@ -501,7 +578,7 @@ int main(int argc, char **argv)
                 label, iface, ifindex,
                 src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
                 dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
-                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : "PCM_s24le-3",
+                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : format_s,
                 channels, rate_hz, nominal_spm, max_samples_per_packet, max_frame);
     } else {
         char ip_str[INET6_ADDRSTRLEN] = {0};
@@ -517,11 +594,12 @@ int main(int argc, char **argv)
         fprintf(stderr,
                 "talker: transport=ip dest=%s:%d family=%s %s\n"
                 "        iface=%s ifindex=%d\n"
-                "        fmt=PCM_s24le-3 ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_payload=%zuB feedback=on\n",
+                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_payload=%zuB feedback=on\n",
                 ip_str, udp_port,
                 dest_family == AF_INET ? "v4" : "v6",
                 dest_is_multicast ? "multicast" : "unicast",
-                iface, ifindex, channels, rate_hz,
+                iface, ifindex,
+                format_s, channels, rate_hz,
                 nominal_spm, max_samples_per_packet,
                 max_frame - sizeof(struct ether_header));
     }
@@ -696,7 +774,7 @@ int main(int argc, char **argv)
             }
 
             const size_t payload_bytes =
-                (size_t)pc * channels * BYTES_PER_SAMPLE;
+                (size_t)pc * channels * bytes_per_sample;
             size_t frame_len_total =
                 sizeof(struct ether_header) + proto_hdr_len + payload_bytes;
 
@@ -716,7 +794,7 @@ int main(int argc, char **argv)
                                    (uint16_t)payload_bytes);
             } else {
                 aoe_hdr_build(aoe_hdr_p, STREAM_ID, seq, 0,
-                              (uint8_t)channels, FORMAT_CODE, (uint8_t)pc,
+                              (uint8_t)channels, format_code, (uint8_t)pc,
                               AOE_FLAG_LAST_IN_GROUP);
             }
 


### PR DESCRIPTION
Extends talker + receiver to carry raw DSD bitstreams over both the L2 and IP/UDP transports.  Wire format adds format codes 0x30..0x33 for native DSD64/128/256/512; the existing per-byte channel-interleave and MSB-first-within-byte convention matches SND_PCM_FORMAT_DSD_U8 1:1, so the receiver needs no reorder step to hand payload straight to ALSA.

  * common/packet.h: AOE_FMT_DOP_DSD* and AOE_FMT_NATIVE_DSD* codes + DSD idle byte (0x69) constant.  DoP codes are reserved but not yet produced by the talker; wiring a DoP encoder is a short follow-up.
  * talker: --format flag (pcm | dsd64 | dsd128 | dsd256 | dsd512). Native DSD overrides --rate with the DSD-bytes-per-sec-per-channel rate so the existing fractional accumulator produces the correct 44/45-alternating payload_count for DSD64 etc. with no math change.  New audio_source_dsd_silence emits 0x69 — acoustically silent on a real DAC, sufficient to verify the wire path.
  * receiver: --format flag picks wire format code and ALSA format (SND_PCM_FORMAT_DSD_U8 for DSD).  Format-code mismatch drops frames as usual.  Mode C feedback path is rate-independent and works unchanged at DSD rates (Q16.16 value sits outside UAC2-HS legal range but AOEther treats it as opaque rate telemetry).
  * Both binaries reject --transport avtp + --format dsd* at startup (IEEE 1722 AAF is PCM-only).
  * docs/recipe-dsd.md: smoke-test procedure, DAC-format caveats, troubleshooting, and a statement of what's deferred.
  * docs/wire-format.md + design.md: updated native-DSD interleave spec and M6 status / out-of-scope list.
  * READMEs: --format flag + DSD recipe link on all three.

Out of scope, tracked as follow-ups:
  * DSD_U32_BE / DSD_U16_LE receive path (transpose by 4 or 2).
  * DoP encoder on talker (wire codes already reserved).
  * DSF / DFF file reader (real DSD playback).
  * DSD1024 / DSD2048 — needs packet splitting, deferred to M8.

Status: code complete; real-DAC listening verification pending hardware access, same pattern as M5.