### PR TITLE
Support DSD_U16_*/DSD_U32_* on receiver; drop DSD512 from M6

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You should hear a clean 1 kHz tone.
 | M3 | Docs ready | Tier 2 hardware (Linux SBC), hardware PTP (Phase A); hardware validation pending board |
 | M4 | In progress | IP/UDP transport, IPv4+IPv6, unicast+multicast, multi-receiver Mode C arbitration |
 | M5 | Code complete | AVTP AAF wire format for Milan interop (interop test pending listener hardware) |
-| M6 | Code complete | Native DSD64 through DSD512 end-to-end (silence smoke-test; DSD_U32_BE follow-up tracked) |
+| M6 | Code complete | Native DSD64–DSD256 end-to-end with DSD_U8 / DSD_U16_* / DSD_U32_* ALSA variants (DSD512+ deferred to M8 with packet splitting) |
 | M7 | Planned | AVDECC, MCU receiver track kickoff |
 | M8 | Planned | Full Atmos scale, DSD1024/2048, packaging |
 | M9 | Planned | Ravenna / AES67 interop |
@@ -98,7 +98,7 @@ AOEther doesn't implement Roon, UPnP, or AirPlay natively — it bridges them vi
 - [`docs/recipe-upnp.md`](docs/recipe-upnp.md) — UPnP / DLNA controllers (via gmrender-resurrect)
 - [`docs/recipe-capture.md`](docs/recipe-capture.md) — desktop audio (browser, Tidal/Spotify apps, etc.) via PipeWire
 - [`docs/recipe-milan.md`](docs/recipe-milan.md) — Milan / AVTP interop: emit AAF to a Milan listener or receive from a Milan talker (M5)
-- [`docs/recipe-dsd.md`](docs/recipe-dsd.md) — native DSD64–DSD512 end-to-end (M6, silence smoke-test; real .dsf playback arrives in M8)
+- [`docs/recipe-dsd.md`](docs/recipe-dsd.md) — native DSD64–DSD256 end-to-end (M6, silence smoke-test; DSD512+ and real .dsf playback arrive in M8)
 
 The same talker and receiver binaries run under every recipe; only the source daemon changes. AirPlay (shairport-sync) and Spotify Connect (librespot) plug in with the same pattern.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -413,23 +413,22 @@ M3 is split into two sub-phases because it's mostly hardware work:
 **Status:** Wire-format and code paths complete; real-DAC listening test pending hardware access.
 
 **Deliverables:**
-- Format codes `0x30..0x33` (native DSD64/128/256/512) defined in `common/packet.h` and wired through talker and receiver.
-- Talker `--format dsd64|dsd128|dsd256|dsd512` switches payload semantics to DSD bytes/microframe (integer alternation around the non-integer target, e.g., 44/45 for DSD64) with no other plumbing changes — the same fractional accumulator that drives PCM payload_count also drives the DSD byte count, so Mode C works unmodified.
+- Format codes `0x30..0x32` (native DSD64/128/256) defined in `common/packet.h` and wired through talker and receiver. DSD512 (`0x33`) and up remain reserved in the wire-format table but are not produced/accepted by talker/receiver until M8 — they need packet splitting because the per-microframe byte count exceeds the u8 `payload_count` field.
+- Talker `--format dsd64|dsd128|dsd256` switches payload semantics to DSD bytes/microframe (integer alternation around the non-integer target, e.g., 44/45 for DSD64) with no other plumbing changes — the same fractional accumulator that drives PCM payload_count also drives the DSD byte count, so Mode C works unmodified.
 - Talker built-in DSD silence source (`--source dsdsilence`, default when `--format` is DSD) emits the `0x69` idle pattern. Enough to verify the wire path and ALSA format selection end to end; real file playback comes in M8.
-- Receiver `--format dsd64..dsd512` opens ALSA at `SND_PCM_FORMAT_DSD_U8`. The wire format's per-byte channel interleaving and MSB-first bit order match DSD_U8 1:1, so no reorder is needed.
-- Mode C clock discipline continues to work under DSD rates (tested in code path; rate numbers are ~352.8..2822.4 samples/ms, outside UAC2 HS feedback legal range but AOEther treats the Q16.16 value as opaque rate telemetry).
+- Receiver `--format` + `--alsa-format` covers the full matrix of DAC quirks: `dsd_u8` (default, 1:1 passthrough), `dsd_u16_be` / `dsd_u16_le`, `dsd_u32_be` / `dsd_u32_le`. For wider-than-wire formats the receiver deinterleaves wire bytes into per-channel streams (carrying up to N-1 bytes per channel across packet boundaries), repacks at ALSA's N-byte-per-channel granularity, and byte-reverses within each group for the `_le` variants.
+- Mode C clock discipline continues to work under DSD rates (tested in code path; rate numbers are ~352.8..1411.2 samples/ms, outside UAC2 HS feedback legal range but AOEther treats the Q16.16 value as opaque rate telemetry).
 - Both L2 (Mode 1) and IP/UDP (Mode 3) transports carry DSD; AVTP (Mode 2) rejects DSD at startup per IEEE 1722 AAF's PCM-only scope.
-- Operator recipe in [`docs/recipe-dsd.md`](recipe-dsd.md) with smoke-test procedure, troubleshooting, and a clear statement of what's deferred.
+- Operator recipe in [`docs/recipe-dsd.md`](recipe-dsd.md) with smoke-test procedure, a DAC → `--alsa-format` mapping table, troubleshooting, and a clear statement of what's deferred.
 
 **Out of scope for M6 (tracked as follow-ups):**
-- `SND_PCM_FORMAT_DSD_U32_BE` / `_U16_LE` on the receiver. These formats require an N-byte-granularity channel interleave, i.e. a small transpose before `snd_pcm_writei`. Many DACs advertise only these formats via `snd_usb_audio` quirks — the follow-up unlocks those. Wire format is unchanged.
 - DoP encoder on the talker (format codes `0x20..0x23`). The wire format already reserves them; wiring up a PCM-wrapped-DSD source needs a small DoP modulator which is straightforward but didn't make M6's code budget.
-- DSF / DFF file reader. `.dsf` is simple (Sony spec, LSB-first per-byte bit order — inverse of our wire format, so a bit-reverse step is needed on read) but the per-DAC quirk testing it enables is better concentrated in M8 alongside DSD1024/2048.
-- DSD1024 / DSD2048. At DSD1024 stereo the per-microframe byte count exceeds MTU; packet splitting + `last-in-group` reassembly arrives in M8.
+- DSF / DFF file reader. `.dsf` is simple (Sony spec, LSB-first per-byte bit order — inverse of our wire format, so a bit-reverse step is needed on read) but the per-DAC quirk testing it enables is better concentrated in M8 alongside DSD512+.
+- DSD512 / DSD1024 / DSD2048. DSD512 overflows the u8 `payload_count` field; DSD1024 stereo additionally breaks the 1500-byte MTU. Packet splitting + `last-in-group` reassembly arrives in M8.
 
 **Key note:** This milestone is dramatically simpler than it was in earlier drafts because `snd_usb_audio` already does the hard work. Our code is about wire format and format selection, not kernel drivers.
 
-**Time estimate:** 2 weekends for wire-format plumbing + silence-path smoke test (done). DAC-matrix build-out (M8 overlap) and U32_BE follow-up add incrementally.
+**Time estimate:** 2 weekends for wire-format plumbing + silence-path smoke test + DSD_U8/U16/U32 variants (done). DAC-matrix build-out (M8 overlap) and DSD512+/DSF-reader/DoP-encoder add incrementally.
 
 ### M7 — AVDECC, discovery, and MCU receiver track kickoff
 

--- a/docs/recipe-dsd.md
+++ b/docs/recipe-dsd.md
@@ -6,21 +6,24 @@ For the wire-format byte layout see [`wire-format.md`](wire-format.md) §"Native
 
 ## What works in M6
 
-- Talker accepts `--format dsd64 | dsd128 | dsd256 | dsd512` and emits raw DSD bits on the wire with format codes `0x30..0x33`.
-- Receiver accepts the same `--format` values and opens ALSA at `SND_PCM_FORMAT_DSD_U8`, which is a 1:1 match for the wire format's per-byte channel interleaving and MSB-first bit order.
+- Talker accepts `--format dsd64 | dsd128 | dsd256` and emits raw DSD bits on the wire with format codes `0x30..0x32`.
+- Receiver accepts the same `--format` values plus an `--alsa-format` override to match the ALSA DSD format your DAC's `snd_usb_audio` quirk exposes:
+  - `dsd_u8` (default) — wire bytes pass through 1:1, zero reorder.
+  - `dsd_u16_le` / `dsd_u16_be` — receiver deinterleaves into per-channel streams and repacks at 2-byte granularity, byte-reversing within each 2-byte group for `_le`.
+  - `dsd_u32_le` / `dsd_u32_be` — same at 4-byte granularity.
+  - The receiver carries up to (N−1) bytes per channel across packet boundaries, so the talker's fractional accumulator can emit any `payload_count` without worrying about ALSA-frame alignment.
 - Mode C clock discipline works at DSD byte rates with no code change — the talker's fractional accumulator and the receiver's `snd_pcm_delay()`-based rate estimator are rate-independent.
 - Works over both L2 (`--transport l2`) and IP/UDP (`--transport ip`). AVTP (`--transport avtp`) does not carry DSD — AAF is PCM-only — and the talker and receiver both reject `avtp + dsd*` at startup.
 
 ## What does NOT work yet
 
-- **Only `SND_PCM_FORMAT_DSD_U8`.** Many modern DACs advertise `SND_PCM_FORMAT_DSD_U32_BE` or `DSD_U16_LE` instead. These work fine with `snd_usb_audio` natively, but require a byte-reorder step in our receiver (4-byte- or 2-byte-granularity channel interleaving instead of 1-byte). That follow-up is tracked in the M6 PR.
-- **Only synthesized silence.** The talker's built-in `--source dsdsilence` emits the DSD idle pattern (`0x69`) on every channel. On a real DAC this plays as silence, which is exactly what's needed to verify the wire path and ALSA format selection work. Playing a real DSD file requires a `.dsf` / `.dff` reader (deferred to M8 alongside DSD1024/2048 — per-DAC quirk testing concentrates there).
+- **DSD512 and higher.** DSD512 stereo needs ~353 bytes per channel per USB microframe, which overflows the wire format's `u8 payload_count` field (max 255). DSD1024 stereo at ~705 bytes per channel additionally breaks the 1500-byte MTU. Both land in M8 with the packet-splitting work and the `last-in-group` reassembly flag.
+- **Only synthesized silence.** The talker's built-in `--source dsdsilence` emits the DSD idle pattern (`0x69`) on every channel. On a real DAC this plays as silence, which is exactly what's needed to verify the wire path and ALSA format selection work. Playing a real DSD file requires a `.dsf` / `.dff` reader (deferred to M8 — per-DAC quirk testing concentrates there).
 - **DoP mode is not wired up.** The wire format reserves codes `0x20..0x23` for DoP (PCM s24le-3 with 0x05 / 0xFA marker bytes at inflated rates), and talker/receiver framework would accept them, but the talker has no DoP encoder source yet. If a DAC works only through DoP and not native DSD, use PCM mode for now and wait for the DoP encoder.
-- **DSD1024 / DSD2048 require packet splitting.** At DSD1024 the per-microframe byte count exceeds 1500-byte MTU for stereo and the talker will refuse the configuration. M8 adds packet splitting and the `last-in-group` reassembly path.
 
 ## Step 1 — smoke test: talker → receiver → DSD DAC
 
-Pick a rate your DAC supports natively. DSD64 and DSD128 are near-universal; DSD256 is common on modern DACs; DSD512 needs a specifically capable DAC.
+Pick a rate your DAC supports natively. DSD64 and DSD128 are near-universal; DSD256 is common on modern DACs. DSD512 is supported on many modern DACs but requires packet splitting on our side, landing in M8.
 
 ```sh
 # Receiver
@@ -37,7 +40,7 @@ sudo ./build/talker --iface eno1 \
 Expected banner output on receiver:
 
 ```
-receiver: transport=l2 iface=eth0 dac=hw:CARD=D90,DEV=0 fmt=dsd64 ch=2 rate=352800 latency_us=5000 feedback=on
+receiver: transport=l2 iface=eth0 dac=hw:CARD=D90,DEV=0 fmt=dsd64 alsa=dsd_u8 ch=2 rate=352800 alsa_rate=352800 latency_us=5000 feedback=on
 ```
 
 Expected on talker:
@@ -55,20 +58,37 @@ On the DAC front panel / status LEDs you should see "DSD64" (or equivalent). Aud
 3. `fb_sent` counter on receiver rises (Mode C active; talker has locked onto the DAC clock).
 4. No xruns / underruns over a 5-minute run.
 
-## Step 2 — if the DAC rejects the stream
+## Step 2 — picking the right `--alsa-format` for your DAC
 
-The most common cause is the DAC not supporting `SND_PCM_FORMAT_DSD_U8`. Check what ALSA sees for your hardware:
+If the default (`dsd_u8`) open fails with `Invalid argument`, the DAC's `snd_usb_audio` quirk probably exposes only a wider DSD format. Check what ALSA says:
 
 ```sh
 cat /proc/asound/card0/pcm0p/sub0/hw_params  # while receiver is running
 # or:
-amixer -c 0 contents  # look for DSD format support
+cat /proc/asound/card0/stream0  # shows the advertised UAC/DSD formats
 ```
 
-If `snd_usb_audio` quirks-table only exposes `DSD_U32_BE` or `DSD_U16_LE` for your DAC, AOEther's M6 `DSD_U8` path cannot drive it. Options:
+Look for a line like `Format: DSD_U32_BE` or `DSD_U16_LE`. Then restart the receiver with a matching override:
 
-- Use PCM mode (`--format pcm --rate 192000`) and accept PCM output until the reorder follow-up lands.
-- Patch `receiver/src/receiver.c::parse_format` to select `SND_PCM_FORMAT_DSD_U32_BE` for your DAC **and** add a transpose-by-4 step before `snd_pcm_writei` (the in-PR follow-up covers this properly).
+```sh
+sudo ./build/receiver --iface eth0 --dac hw:CARD=D90,DEV=0 \
+                      --format dsd64 --alsa-format dsd_u32_be
+```
+
+The receiver deinterleaves the wire bytes into per-channel streams, repacks them at the right granularity (2 or 4 bytes per channel per ALSA frame), and reverses byte order within each group for `_le` variants. Any leftover bytes below one ALSA-frame's worth are carried over to the next packet, so payload alignment on the wire is not a concern.
+
+Common quirk → flag mapping:
+
+| DAC family                    | Typical ALSA format | Flag              |
+|-------------------------------|---------------------|-------------------|
+| Topping D90 / E70 / A90D      | DSD_U32_BE          | `dsd_u32_be`      |
+| SMSL M500 / M400              | DSD_U32_BE          | `dsd_u32_be`      |
+| RME ADI-2 DAC                 | DSD_U32_BE          | `dsd_u32_be`      |
+| Holo May / Spring / Cyan      | DSD_U32_BE          | `dsd_u32_be`      |
+| Older iFi / Chord             | DSD_U16_LE          | `dsd_u16_le`      |
+| DACs with pure DSD-UAC support | DSD_U8             | `dsd_u8` (default) |
+
+These are typical — trust `/proc/asound` over this table.
 
 ## Step 3 — playing real DSD content
 
@@ -95,10 +115,10 @@ Mode C feedback still applies and behaves identically to PCM: the receiver sampl
 
 ## Troubleshooting
 
-**Receiver: `snd_pcm_set_params (ch=2 rate=352800 fmt=dsd64): Invalid argument`** — DAC doesn't advertise DSD_U8. See Step 2 above.
+**Receiver: `snd_pcm_set_params (ch=2 alsa_rate=... fmt=dsd64 alsa=dsd_u8): Invalid argument`** — DAC doesn't advertise DSD_U8 at that rate. See Step 2 above and try `--alsa-format dsd_u32_be` (most common) or `dsd_u16_le`.
 
 **Talker: `AVTP AAF does not carry DSD; use --transport l2 or ip with --format dsd*`** — correct; AAF is PCM-only. Switch transport.
 
 **Receiver: `dropped` counter rises with `rx=0`** — frames are arriving but the format code in the header doesn't match CLI. Make sure both talker and receiver use the same `--format`.
 
-**Receiver: `underruns` counter rises steadily** — DSD bandwidth at DSD512 stereo is ~22 Mbps; if the network or the DAC's USB path can't sustain that, underruns follow. Try a lower DSD rate or check for USB 2.0 hub contention (DSD512 requires a direct USB 2.0 HS connection, no hub in most cases).
+**Receiver: `underruns` counter rises steadily** — DSD bandwidth at DSD256 stereo is ~11 Mbps; if the network or the DAC's USB path can't sustain that, underruns follow. Try a lower DSD rate or check for USB 2.0 hub contention (DSD256+ generally wants a direct USB 2.0 HS connection, no hub in most cases).

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -37,7 +37,8 @@ Flags:
 - `--group IP` — multicast group to join (IP mode only). IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8. Omit for unicast.
 - `--channels N` — channel count (1..64, default 2). Must match the talker.
 - `--rate HZ` — PCM only: one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Must match the talker. Ignored for DSD — rate is implied by `--format`.
-- `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256 | dsd512` (M6). DSD uses `SND_PCM_FORMAT_DSD_U8`; DACs requiring `DSD_U32_BE` / `DSD_U16_LE` are a follow-up. See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
+- `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256` (M6). DSD512+ needs packet splitting (deferred to M8). See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
+- `--alsa-format FMT` — ALSA sample format. Defaults: PCM → `pcm_s24_3le`; DSD → `dsd_u8`. Override for DSD with `dsd_u8 | dsd_u16_le | dsd_u16_be | dsd_u32_le | dsd_u32_be` to match whatever your DAC's `snd_usb_audio` quirk exposes; the receiver handles the transpose and endian conversion on ingress.
 - `--latency-us N` — ALSA period latency hint (default 5000 µs). Generous on purpose; the Mode C loop corrects ppm-scale drift slowly and the buffer also absorbs talker-side `timerfd` jitter.
 - `--no-feedback` — disable FEEDBACK emission. **Diagnostic only** — the positive control for the soak test (design.md §M1 test 7): with feedback off, the stream is expected to drift and xrun within minutes, confirming Mode C is doing real work when it's on.
 
@@ -46,8 +47,8 @@ Needs `CAP_NET_RAW` for the raw sockets in L2 mode; easiest path is `sudo`. IP m
 ## What it does, exactly
 
 - Opens two `AF_PACKET` sockets: one for RX on EtherType `0x88B5` (data — or `0x22F0` with `--transport avtp`), one for TX on `0x88B6` (Mode C FEEDBACK).
-- Accepts only data frames whose format code matches `--format`: `0x11` (PCM s24le-3) for `--format pcm`, or `0x30..0x33` for `--format dsd64..dsd512`.
-- Opens the named ALSA device at the matching ALSA format (`S24_3LE` for PCM, `DSD_U8` for native DSD), with soft-resample disabled.
+- Accepts only data frames whose format code matches `--format`: `0x11` (PCM s24le-3) for `--format pcm`, or `0x30..0x32` for `--format dsd64..dsd256`.
+- Opens the named ALSA device at whichever format `--alsa-format` selected (default `S24_3LE` for PCM, `DSD_U8` for native DSD), with soft-resample disabled. For wider DSD variants (`DSD_U16_*` / `DSD_U32_*`) the receiver deinterleaves wire bytes into per-channel streams (buffering up to N-1 bytes per channel across packet boundaries) and repacks into ALSA's N-byte frames, reversing byte order within each group for the `_LE` variants.
 - Forwards payload bytes directly into `snd_pcm_writei`. ALSA is the jitter buffer; `snd_usb_audio` is the UAC2 stack and runs UAC2 async feedback with the DAC.
 - On xrun (`EPIPE`) calls `snd_pcm_prepare`, re-seeds the rate estimator, and continues.
 - Tracks sequence-number gaps for loss reporting; no reorder buffer in M1.

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -29,7 +29,7 @@
 #define DSD64_BYTE_RATE   352800
 #define DSD128_BYTE_RATE  705600
 #define DSD256_BYTE_RATE  1411200
-#define DSD512_BYTE_RATE  2822400
+/* DSD512 exceeds the u8 payload_count limit — needs packet splitting (M8). */
 
 /* Defaults match M1's previous hardcoded values. */
 #define DEFAULT_CHANNELS      2
@@ -67,30 +67,62 @@ struct stream_format {
     uint8_t              wire_code;
     int                  bytes_per_sample;
     int                  rate_override;   /* >0 overrides --rate (DSD) */
-    snd_pcm_format_t     alsa_format;
     int                  is_dsd;
     const char          *name;
 };
 
-/* M6 ships DSD via SND_PCM_FORMAT_DSD_U8 only, which matches the wire-format
- * byte order 1:1 (per-byte channel interleaving, MSB-first within each
- * byte). DACs that require DSD_U16/U32 formats arrive in a follow-up with
- * a reorder step. */
 static int parse_format(const char *s, struct stream_format *f)
 {
     if (!s) return -1;
     static const struct stream_format table[] = {
-        { AOE_FMT_PCM_S24LE_3,   3, 0,                SND_PCM_FORMAT_S24_3LE, 0, "pcm"    },
-        { AOE_FMT_NATIVE_DSD64,  1, DSD64_BYTE_RATE,  SND_PCM_FORMAT_DSD_U8,  1, "dsd64"  },
-        { AOE_FMT_NATIVE_DSD128, 1, DSD128_BYTE_RATE, SND_PCM_FORMAT_DSD_U8,  1, "dsd128" },
-        { AOE_FMT_NATIVE_DSD256, 1, DSD256_BYTE_RATE, SND_PCM_FORMAT_DSD_U8,  1, "dsd256" },
-        { AOE_FMT_NATIVE_DSD512, 1, DSD512_BYTE_RATE, SND_PCM_FORMAT_DSD_U8,  1, "dsd512" },
+        { AOE_FMT_PCM_S24LE_3,   3, 0,                0, "pcm"    },
+        { AOE_FMT_NATIVE_DSD64,  1, DSD64_BYTE_RATE,  1, "dsd64"  },
+        { AOE_FMT_NATIVE_DSD128, 1, DSD128_BYTE_RATE, 1, "dsd128" },
+        { AOE_FMT_NATIVE_DSD256, 1, DSD256_BYTE_RATE, 1, "dsd256" },
+        /* DSD512 and higher need packet splitting: nominal bytes/ch per
+         * microframe exceeds the wire format's u8 payload_count field (255).
+         * Lifting that is M8 scope. */
     };
     for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
         if (strcmp(s, table[i].name) == 0) {
-            /* Re-assign the name pointer to the found table entry's literal
-             * so callers can keep using f->name safely. */
             *f = table[i];
+            return 0;
+        }
+    }
+    return -1;
+}
+
+/* ALSA DSD format selection. The AOE wire format is always per-byte channel-
+ * interleaved MSB-first within each byte; that matches DSD_U8 exactly. For
+ * the wider DSD_U16_* / DSD_U32_* formats the receiver deinterleaves wire
+ * bytes into per-channel linear streams (buffering up to N-1 bytes per
+ * channel across packet boundaries) and repacks into ALSA's N-byte-per-
+ * channel frames, byte-reversing within each group for the LE variants.
+ *
+ * PCM uses SND_PCM_FORMAT_S24_3LE with n_bytes=3 and no group reversal —
+ * the wire format already delivers those bytes in ALSA's expected order. */
+struct alsa_variant {
+    const char       *name;
+    snd_pcm_format_t  alsa_format;
+    int               n_bytes;   /* bytes per channel per ALSA frame */
+    int               reverse;   /* 1 → byte-reverse within each N-byte group */
+    int               is_dsd;
+};
+
+static int parse_alsa_variant(const char *s, struct alsa_variant *v)
+{
+    if (!s) return -1;
+    static const struct alsa_variant table[] = {
+        { "pcm_s24_3le", SND_PCM_FORMAT_S24_3LE,    3, 0, 0 },
+        { "dsd_u8",      SND_PCM_FORMAT_DSD_U8,     1, 0, 1 },
+        { "dsd_u16_be",  SND_PCM_FORMAT_DSD_U16_BE, 2, 0, 1 },
+        { "dsd_u16_le",  SND_PCM_FORMAT_DSD_U16_LE, 2, 1, 1 },
+        { "dsd_u32_be",  SND_PCM_FORMAT_DSD_U32_BE, 4, 0, 1 },
+        { "dsd_u32_le",  SND_PCM_FORMAT_DSD_U32_LE, 4, 1, 1 },
+    };
+    for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
+        if (strcmp(s, table[i].name) == 0) {
+            *v = table[i];
             return 0;
         }
     }
@@ -114,9 +146,15 @@ static void usage(const char *prog)
         "  --port N             UDP port (IP mode, default %d)\n"
         "  --group IP           multicast group to join (IP mode, optional;\n"
         "                       IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8)\n"
-        "  --format FMT         pcm | dsd64 | dsd128 | dsd256 | dsd512\n"
+        "  --format FMT         pcm | dsd64 | dsd128 | dsd256\n"
         "                       default pcm. AVTP transport is pcm-only.\n"
-        "                       DSD uses SND_PCM_FORMAT_DSD_U8 (per-DAC quirks apply).\n"
+        "                       DSD512+ needs packet splitting, deferred to M8.\n"
+        "  --alsa-format FMT    ALSA sample format. Default picks from --format:\n"
+        "                         pcm → pcm_s24_3le; dsd* → dsd_u8.\n"
+        "                       DSD override: dsd_u8 | dsd_u16_le | dsd_u16_be |\n"
+        "                                     dsd_u32_le | dsd_u32_be.\n"
+        "                       Match whatever your DAC's snd_usb_audio quirk exposes;\n"
+        "                       the receiver handles the transpose + endian conversion.\n"
         "  --channels N         stream channel count (1..64, default %d)\n"
         "  --rate HZ            PCM only: 44100|48000|88200|96000|176400|192000\n"
         "                       (default %d; ignored for DSD — rate is implied by --format)\n"
@@ -155,6 +193,7 @@ int main(int argc, char **argv)
     const char *dac = NULL;
     const char *group_s = NULL;
     const char *format_s = "pcm";
+    const char *alsa_format_s = NULL;   /* resolved below from --format if NULL */
     int channels = DEFAULT_CHANNELS;
     int rate_hz = DEFAULT_RATE_HZ;
     int latency_us = DEFAULT_LATENCY_US;
@@ -171,13 +210,14 @@ int main(int argc, char **argv)
         { "channels",    required_argument, 0, 'C' },
         { "rate",        required_argument, 0, 'r' },
         { "format",      required_argument, 0, 'F' },
+        { "alsa-format", required_argument, 0, 'A' },
         { "latency-us",  required_argument, 0, 'l' },
         { "no-feedback", no_argument,       0, 'n' },
         { "help",        no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:F:l:nh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:F:A:l:nh", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dac = optarg; break;
@@ -192,6 +232,7 @@ int main(int argc, char **argv)
         case 'C': channels = atoi(optarg); break;
         case 'r': rate_hz = atoi(optarg); break;
         case 'F': format_s = optarg; break;
+        case 'A': alsa_format_s = optarg; break;
         case 'l': latency_us = atoi(optarg); break;
         case 'n': feedback_enabled = 0; break;
         case 'h': usage(argv[0]); return 0;
@@ -242,6 +283,22 @@ int main(int argc, char **argv)
     }
     const int bytes_per_sample = fmt.bytes_per_sample;
     const uint8_t expected_format_code = fmt.wire_code;
+
+    /* Resolve ALSA variant. Default derives from --format; user can override
+     * for DSD when the DAC's snd_usb_audio quirk exposes only DSD_U16 / U32. */
+    struct alsa_variant av;
+    if (!alsa_format_s) alsa_format_s = fmt.is_dsd ? "dsd_u8" : "pcm_s24_3le";
+    if (parse_alsa_variant(alsa_format_s, &av) < 0) {
+        fprintf(stderr, "receiver: unknown --alsa-format %s\n", alsa_format_s);
+        return 2;
+    }
+    if (av.is_dsd != fmt.is_dsd) {
+        fprintf(stderr,
+                "receiver: --alsa-format %s is %s but --format %s is %s\n",
+                alsa_format_s, av.is_dsd ? "DSD" : "PCM",
+                fmt.name, fmt.is_dsd ? "DSD" : "PCM");
+        return 2;
+    }
 
     /* Socket setup per transport. L2 keeps two raw AF_PACKET sockets (one
      * per EtherType). IP uses one SOCK_DGRAM socket bound to udp_port —
@@ -369,22 +426,28 @@ int main(int argc, char **argv)
         fprintf(stderr, "snd_pcm_open(%s): %s\n", dac, snd_strerror(err));
         return 1;
     }
+    /* ALSA's "frame rate" differs from wire rate_hz for wider DSD formats:
+     * each ALSA frame consumes av.n_bytes bytes per channel, so
+     *   ALSA rate = (wire DSD byte rate per channel) / av.n_bytes.
+     * For PCM S24_3LE the two concepts coincide. */
+    const unsigned alsa_rate = fmt.is_dsd
+        ? (unsigned)rate_hz / (unsigned)av.n_bytes
+        : (unsigned)rate_hz;
     err = snd_pcm_set_params(pcm,
-                             fmt.alsa_format,
+                             av.alsa_format,
                              SND_PCM_ACCESS_RW_INTERLEAVED,
                              (unsigned int)channels,
-                             (unsigned int)rate_hz,
+                             alsa_rate,
                              0,              /* disable ALSA soft-resample */
                              (unsigned int)latency_us);
     if (err < 0) {
         fprintf(stderr,
-                "snd_pcm_set_params (ch=%d rate=%d fmt=%s): %s\n"
+                "snd_pcm_set_params (ch=%d alsa_rate=%u fmt=%s alsa=%s): %s\n"
                 "  (DAC must natively support this configuration; "
-                "AOEther never resamples.  For DSD, check that the DAC's\n"
-                "  snd_usb_audio quirk exposes %s at this rate; some DACs\n"
-                "  require DSD_U32_BE instead, which is a follow-up.)\n",
-                channels, rate_hz, fmt.name, snd_strerror(err),
-                fmt.is_dsd ? "SND_PCM_FORMAT_DSD_U8" : "S24_3LE");
+                "AOEther never resamples.  For DSD, try a different\n"
+                "  --alsa-format matching your DAC's snd_usb_audio quirk\n"
+                "  — common variants are dsd_u8, dsd_u16_le, dsd_u32_be.)\n",
+                channels, alsa_rate, fmt.name, alsa_format_s, snd_strerror(err));
         return 1;
     }
 
@@ -393,22 +456,24 @@ int main(int argc, char **argv)
 
     if (transport != TRANSPORT_IP) {
         fprintf(stderr,
-                "receiver: transport=%s iface=%s dac=%s fmt=%s ch=%d rate=%d latency_us=%d feedback=%s\n",
+                "receiver: transport=%s iface=%s dac=%s fmt=%s alsa=%s ch=%d rate=%d alsa_rate=%u latency_us=%d feedback=%s\n",
                 transport == TRANSPORT_AVTP ? "avtp" : "l2",
                 iface, dac,
-                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)→S24_3LE" : fmt.name,
-                channels, rate_hz, latency_us,
+                transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : fmt.name,
+                av.name,
+                channels, rate_hz, alsa_rate, latency_us,
                 feedback_enabled ? "on" : "off");
     } else {
         fprintf(stderr,
                 "receiver: transport=ip family=%s %s port=%d%s%s\n"
-                "          iface=%s dac=%s fmt=%s ch=%d rate=%d latency_us=%d feedback=%s\n",
+                "          iface=%s dac=%s fmt=%s alsa=%s ch=%d rate=%d alsa_rate=%u latency_us=%d feedback=%s\n",
                 group_family == AF_INET6 ? "v6" : "v4",
                 use_multicast ? "multicast" : "unicast",
                 udp_port,
                 group_s ? " group=" : "",
                 group_s ? group_s : "",
-                iface, dac, fmt.name, channels, rate_hz, latency_us,
+                iface, dac, fmt.name, av.name,
+                channels, rate_hz, alsa_rate, latency_us,
                 feedback_enabled ? "on" : "off");
     }
 
@@ -417,6 +482,14 @@ int main(int argc, char **argv)
     uint32_t last_seq = 0;
     int have_seq = 0;
     uint64_t rx = 0, dropped = 0, lost = 0, underruns = 0;
+
+    /* DSD repack scratch for the DSD_U16 / DSD_U32 paths. Worst case is
+     * channels=64 × (n_bytes-1=3 leftover + max payload_count=255) = 16512
+     * bytes per channel view; round up. For DSD_U8 / PCM these are unused. */
+    uint8_t dsd_per_ch[64 * (3 + 256)];
+    uint8_t dsd_out[RX_BUF_BYTES];
+    uint8_t dsd_leftover[64 * 3];
+    int     dsd_leftover_per_ch = 0;
 
     /* Mode C state. */
     uint64_t frames_written_total = 0;
@@ -569,11 +642,74 @@ int main(int argc, char **argv)
                 have_talker = 1;
             }
 
-            snd_pcm_sframes_t w = snd_pcm_writei(pcm, payload_p, frames);
+            /* For DSD formats wider than U8, deinterleave wire bytes into
+             * per-channel streams (carrying up to N-1 bytes per channel
+             * across packet boundaries), then repack into ALSA's N-byte-per-
+             * channel frames, byte-reversing within each group for LE
+             * variants. For DSD_U8 and PCM the wire layout already matches
+             * what ALSA expects and payload_p is passed through unchanged. */
+            const uint8_t *alsa_p = payload_p;
+            size_t alsa_frames = frames;
+            if (fmt.is_dsd && av.n_bytes > 1) {
+                const int wire_per_ch = (int)frames;
+                const int total_per_ch = dsd_leftover_per_ch + wire_per_ch;
+                const int af = total_per_ch / av.n_bytes;
+                const int consumed_per_ch = af * av.n_bytes;
+                const int new_leftover = total_per_ch - consumed_per_ch;
+
+                /* Build per-channel linear streams: leftover bytes first,
+                 * then deinterleaved wire bytes. */
+                for (int c = 0; c < channels; c++) {
+                    uint8_t *dst = dsd_per_ch + c * total_per_ch;
+                    memcpy(dst,
+                           dsd_leftover + c * dsd_leftover_per_ch,
+                           (size_t)dsd_leftover_per_ch);
+                    for (int i = 0; i < wire_per_ch; i++) {
+                        dst[dsd_leftover_per_ch + i] =
+                            payload_p[i * channels + c];
+                    }
+                }
+
+                /* Save the new leftover (bytes beyond the last whole ALSA
+                 * frame boundary) for the next packet. */
+                for (int c = 0; c < channels; c++) {
+                    memcpy(dsd_leftover + c * new_leftover,
+                           dsd_per_ch + c * total_per_ch + consumed_per_ch,
+                           (size_t)new_leftover);
+                }
+                dsd_leftover_per_ch = new_leftover;
+
+                /* Pack ALSA output: for each ALSA frame f, for each channel
+                 * c, copy av.n_bytes bytes from the per-channel stream,
+                 * optionally byte-reversing within the group for _LE. */
+                for (int f = 0; f < af; f++) {
+                    for (int c = 0; c < channels; c++) {
+                        const uint8_t *src =
+                            dsd_per_ch + c * total_per_ch + f * av.n_bytes;
+                        uint8_t *dst =
+                            dsd_out + f * channels * av.n_bytes + c * av.n_bytes;
+                        if (av.reverse) {
+                            for (int i = 0; i < av.n_bytes; i++) {
+                                dst[av.n_bytes - 1 - i] = src[i];
+                            }
+                        } else {
+                            memcpy(dst, src, (size_t)av.n_bytes);
+                        }
+                    }
+                }
+                alsa_p = dsd_out;
+                alsa_frames = (size_t)af;
+            }
+
+            snd_pcm_sframes_t w = 0;
+            if (alsa_frames > 0) {
+                w = snd_pcm_writei(pcm, alsa_p, alsa_frames);
+            }
             if (w == -EPIPE) {
                 underruns++;
                 snd_pcm_prepare(pcm);
                 rate_bootstrapped = 0;
+                dsd_leftover_per_ch = 0;  /* drop pending on xrun */
             } else if (w < 0) {
                 int r = snd_pcm_recover(pcm, (int)w, 1);
                 if (r < 0) {
@@ -581,6 +717,7 @@ int main(int argc, char **argv)
                     break;
                 }
                 rate_bootstrapped = 0;
+                dsd_leftover_per_ch = 0;
             } else {
                 rx++;
                 frames_written_total += (uint64_t)w;

--- a/talker/README.md
+++ b/talker/README.md
@@ -32,13 +32,13 @@ Flags:
 - `--capture hw:CARD=...` — ALSA PCM name when `--source alsa`. Point at one half of a `snd-aloop` pair to receive from Roon/UPnP/PipeWire; see `docs/recipe-*.md`.
 - `--channels N` — channel count (1..64, default 2). Receiver must match.
 - `--rate HZ` — PCM only: one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Ignored for DSD — rate is implied by `--format`.
-- `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256 | dsd512` (M6). AVTP transport is PCM-only and rejects `dsd*` at startup. See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
+- `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256` (M6). DSD512+ needs packet splitting (deferred to M8). AVTP transport is PCM-only and rejects `dsd*` at startup. See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
 
 Needs `CAP_NET_RAW` to open `AF_PACKET` in L2 mode; easiest path is `sudo`. IP mode doesn't require root in principle (bind on ephemeral port is unprivileged), but if you want to bind to port 8805 < 1024 you'd need capabilities anyway — 8805 is fine without.
 
 ## What it does, exactly
 
-- Stream ID `0x0001`. Format code is chosen by `--format`: `0x11` (PCM s24le-3, default), or `0x30..0x33` (native DSD64..DSD512, M6). Channels and rate are runtime-configured via `--channels` and `--rate`; defaults match M1 (2 channels, 48 kHz PCM).
+- Stream ID `0x0001`. Format code is chosen by `--format`: `0x11` (PCM s24le-3, default), or `0x30..0x32` (native DSD64..DSD256, M6). Channels and rate are runtime-configured via `--channels` and `--rate`; defaults match M1 (2 channels, 48 kHz PCM).
 - Emits 1 packet per 125 µs tick from `timerfd`. The timer never retunes.
 - Ethernet II frame, EtherType `0x88B5`, AoE header per [`docs/wire-format.md`](../docs/wire-format.md). With `--transport avtp` the wrapper switches to IEEE 1722 AAF (24-byte header, samples big-endian on the wire) at EtherType `0x22F0`; Mode C feedback continues on `0x88B6` regardless.
 - `payload_count` is **nominally `rate_hz / 8000` samples per packet but varies under Mode C feedback** — the talker keeps a fractional sample accumulator driven by the latest FEEDBACK value and writes the integer part into each packet. This is how USB hosts drive async DACs; we extend the same scheme across Ethernet.

--- a/talker/src/audio_source.h
+++ b/talker/src/audio_source.h
@@ -16,7 +16,7 @@ struct audio_source *audio_source_wav_open(const char *path);
 struct audio_source *audio_source_alsa_open(const char *pcm_name, int channels, int rate);
 
 /* DSD silence source (M6). `dsd_byte_rate` is bits/sec/channel ÷ 8; for
- * DSD64 it's 352800, for DSD512 it's 2822400. `read()` returns the idle
+ * DSD64 it's 352800, for DSD256 it's 1411200. `read()` returns the idle
  * pattern (`AOE_DSD_IDLE_BYTE`) interleaved across channels — acoustically
  * silent on a real DAC, but exercises the full wire-format and ALSA
  * native-DSD path. A real DSF/DFF file reader is deferred to M8 alongside

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -37,7 +37,8 @@
 #define DSD64_BYTE_RATE       352800       /* 2.8224 MHz / 8 */
 #define DSD128_BYTE_RATE      705600
 #define DSD256_BYTE_RATE      1411200
-#define DSD512_BYTE_RATE      2822400
+/* DSD512 (2.8224 MB/s/ch) exceeds the wire format's u8 payload_count (255)
+ * and needs packet splitting — deferred to M8. */
 
 /* Ethernet II data payload max (frame - eth header) for standard 1500 MTU. */
 #define ETH_MTU_PAYLOAD       1500
@@ -92,7 +93,8 @@ static int parse_format(const char *s, struct stream_format *f)
         { AOE_FMT_NATIVE_DSD64,   1, DSD64_BYTE_RATE,     1, "dsd64"  },
         { AOE_FMT_NATIVE_DSD128,  1, DSD128_BYTE_RATE,    1, "dsd128" },
         { AOE_FMT_NATIVE_DSD256,  1, DSD256_BYTE_RATE,    1, "dsd256" },
-        { AOE_FMT_NATIVE_DSD512,  1, DSD512_BYTE_RATE,    1, "dsd512" },
+        /* DSD512+ overflows the wire format's u8 payload_count field; it
+         * lands in M8 alongside the packet-splitting work. */
     };
     for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
         if (strcmp(s, table[i].name) == 0) {
@@ -170,8 +172,9 @@ static void usage(const char *prog)
         "  --capture hw:CARD=...        ALSA capture device, required with --source alsa\n"
         "\n"
         "Stream format:\n"
-        "  --format  FMT                pcm | dsd64 | dsd128 | dsd256 | dsd512\n"
-        "                               default pcm. DoP and DSD1024+ are deferred.\n"
+        "  --format  FMT                pcm | dsd64 | dsd128 | dsd256\n"
+        "                               default pcm. DoP and DSD512+ are deferred\n"
+        "                               (DSD512+ needs packet splitting → M8).\n"
         "                               AVTP transport carries pcm only.\n"
         "  --channels N                 channel count (1..64, default %d)\n"
         "  --rate    HZ                 44100|48000|88200|96000|176400|192000 (default %d)\n"


### PR DESCRIPTION
Follow-up on M6.  Two related changes:

1.  Receiver --alsa-format picks the ALSA DSD variant explicitly: dsd_u8 (default, 1:1 passthrough), dsd_u16_be, dsd_u16_le, dsd_u32_be, dsd_u32_le.  For wider-than-wire formats the receiver deinterleaves wire bytes into per-channel streams (buffering up to N-1 bytes per channel across packet boundaries so the talker can emit any payload_count), repacks at ALSA's N-byte granularity, and byte-reverses within each group for the _le variants.  ALSA rate is recomputed as wire-rate / n_bytes for DSD.

    This unblocks the large set of DACs (Topping D90/E70, SMSL M500, Holo May, RME ADI-2, ...) whose snd_usb_audio quirk exposes only DSD_U32_BE.  Recipe doc adds a DAC → flag mapping table.

2.  Drop DSD512 from M6's supported --format set.  DSD512 stereo emits ~353 bytes per channel per USB microframe, which overflows the wire format's u8 payload_count field (max 255).  The M6 code as originally merged would silently truncate and produce garbled audio.  DSD512 lands in M8 alongside the packet-splitting work that's also needed for DSD1024/2048.  Wire-format table keeps 0x33 reserved.

Also updates docs (receiver README, design.md, recipe-dsd.md) and the talker's compile-time DSD rate constants accordingly.