### PR TITLE
Add mDNS-SD discovery for receivers (M7 Phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You should hear a clean 1 kHz tone.
 | M4 | In progress | IP/UDP transport, IPv4+IPv6, unicast+multicast, multi-receiver Mode C arbitration |
 | M5 | Code complete | AVTP AAF wire format for Milan interop (interop test pending listener hardware) |
 | M6 | Code complete | Native DSD64 through DSD512 end-to-end (silence smoke-test; DSD_U32_BE follow-up tracked) |
-| M7 | Planned | AVDECC, MCU receiver track kickoff |
+| M7 | Phase A in progress | Phase A: mDNS-SD discovery (code complete). Phase B: AVDECC entity. Phase C: MCU receiver track. |
 | M8 | Planned | Full Atmos scale, DSD1024/2048, packaging |
 | M9 | Planned | Ravenna / AES67 interop |
 
@@ -99,6 +99,7 @@ AOEther doesn't implement Roon, UPnP, or AirPlay natively — it bridges them vi
 - [`docs/recipe-capture.md`](docs/recipe-capture.md) — desktop audio (browser, Tidal/Spotify apps, etc.) via PipeWire
 - [`docs/recipe-milan.md`](docs/recipe-milan.md) — Milan / AVTP interop: emit AAF to a Milan listener or receive from a Milan talker (M5)
 - [`docs/recipe-dsd.md`](docs/recipe-dsd.md) — native DSD64–DSD512 end-to-end (M6, silence smoke-test; real .dsf playback arrives in M8)
+- [`docs/recipe-discovery.md`](docs/recipe-discovery.md) — mDNS-SD receiver discovery via `--announce` and `aoether-browse` (M7 Phase A)
 
 The same talker and receiver binaries run under every recipe; only the source daemon changes. AirPlay (shairport-sync) and Spotify Connect (librespot) plug in with the same pattern.
 

--- a/common/mdns.c
+++ b/common/mdns.c
@@ -1,0 +1,224 @@
+/* Avahi-backed mDNS-SD publisher. See mdns.h for API contract.
+ *
+ * Build with `-DAOETHER_HAVE_AVAHI` and `-lavahi-client -lavahi-common` to
+ * get the real implementation; otherwise mdns_stub.c is compiled instead
+ * and all calls become no-ops.
+ */
+
+#include "mdns.h"
+
+#ifdef AOETHER_HAVE_AVAHI
+
+#include <avahi-client/client.h>
+#include <avahi-client/publish.h>
+#include <avahi-common/alternative.h>
+#include <avahi-common/error.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/thread-watch.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct aoether_mdns {
+    AvahiThreadedPoll *poll;
+    AvahiClient       *client;
+    AvahiEntryGroup   *group;
+    char              *service_type;
+    char              *instance_name;   /* owned; may be renamed on collision */
+    uint16_t           port;
+    AvahiStringList   *txt;             /* owned */
+};
+
+static void entry_group_cb(AvahiEntryGroup *g, AvahiEntryGroupState state, void *userdata);
+static void client_cb(AvahiClient *c, AvahiClientState state, void *userdata);
+
+static int add_service(struct aoether_mdns *m)
+{
+    int rc;
+    if (!m->group) {
+        m->group = avahi_entry_group_new(m->client, entry_group_cb, m);
+        if (!m->group) {
+            fprintf(stderr, "mdns: avahi_entry_group_new failed: %s\n",
+                    avahi_strerror(avahi_client_errno(m->client)));
+            return -1;
+        }
+    }
+
+    rc = avahi_entry_group_add_service_strlst(m->group,
+                                              AVAHI_IF_UNSPEC,
+                                              AVAHI_PROTO_UNSPEC,
+                                              0,
+                                              m->instance_name,
+                                              m->service_type,
+                                              NULL, NULL,
+                                              m->port,
+                                              m->txt);
+    if (rc == AVAHI_ERR_COLLISION) {
+        char *n = avahi_alternative_service_name(m->instance_name);
+        if (!n) return -1;
+        avahi_free(m->instance_name);
+        m->instance_name = strdup(n);
+        avahi_free(n);
+        if (!m->instance_name) return -1;
+        avahi_entry_group_reset(m->group);
+        return add_service(m);
+    }
+    if (rc < 0) {
+        fprintf(stderr, "mdns: add_service(%s) failed: %s\n",
+                m->service_type, avahi_strerror(rc));
+        return -1;
+    }
+
+    rc = avahi_entry_group_commit(m->group);
+    if (rc < 0) {
+        fprintf(stderr, "mdns: commit failed: %s\n", avahi_strerror(rc));
+        return -1;
+    }
+    return 0;
+}
+
+static void entry_group_cb(AvahiEntryGroup *g, AvahiEntryGroupState state, void *userdata)
+{
+    struct aoether_mdns *m = userdata;
+    switch (state) {
+    case AVAHI_ENTRY_GROUP_ESTABLISHED:
+        fprintf(stderr, "mdns: published %s as \"%s\"\n",
+                m->service_type, m->instance_name);
+        break;
+    case AVAHI_ENTRY_GROUP_COLLISION: {
+        char *n = avahi_alternative_service_name(m->instance_name);
+        if (n) {
+            avahi_free(m->instance_name);
+            m->instance_name = strdup(n);
+            avahi_free(n);
+            fprintf(stderr, "mdns: name collision, retrying as \"%s\"\n",
+                    m->instance_name);
+            add_service(m);
+        }
+        break;
+    }
+    case AVAHI_ENTRY_GROUP_FAILURE:
+        fprintf(stderr, "mdns: entry group failed: %s\n",
+                avahi_strerror(avahi_client_errno(m->client)));
+        break;
+    case AVAHI_ENTRY_GROUP_UNCOMMITED:
+    case AVAHI_ENTRY_GROUP_REGISTERING:
+    default:
+        break;
+    }
+    (void)g;
+}
+
+static void client_cb(AvahiClient *c, AvahiClientState state, void *userdata)
+{
+    struct aoether_mdns *m = userdata;
+    m->client = c;
+    switch (state) {
+    case AVAHI_CLIENT_S_RUNNING:
+        add_service(m);
+        break;
+    case AVAHI_CLIENT_FAILURE:
+        fprintf(stderr, "mdns: client failure: %s\n",
+                avahi_strerror(avahi_client_errno(c)));
+        break;
+    case AVAHI_CLIENT_S_COLLISION:
+    case AVAHI_CLIENT_S_REGISTERING:
+        if (m->group) avahi_entry_group_reset(m->group);
+        break;
+    case AVAHI_CLIENT_CONNECTING:
+    default:
+        break;
+    }
+}
+
+struct aoether_mdns *aoether_mdns_publish(const char *service_type,
+                                          const char *instance_name,
+                                          uint16_t port,
+                                          const struct aoether_mdns_txt *txt,
+                                          size_t txt_count)
+{
+    if (!service_type || !instance_name) return NULL;
+
+    struct aoether_mdns *m = calloc(1, sizeof(*m));
+    if (!m) return NULL;
+    m->port = port;
+    m->service_type = strdup(service_type);
+    m->instance_name = strdup(instance_name);
+    if (!m->service_type || !m->instance_name) goto fail;
+
+    for (size_t i = 0; i < txt_count; i++) {
+        const struct aoether_mdns_txt *t = &txt[i];
+        if (!t->key) continue;
+        char buf[256];
+        if (t->value) {
+            int n = snprintf(buf, sizeof(buf), "%s=%s", t->key, t->value);
+            if (n <= 0 || (size_t)n >= sizeof(buf)) continue;
+        } else {
+            size_t kl = strlen(t->key);
+            if (kl >= sizeof(buf)) continue;
+            memcpy(buf, t->key, kl + 1);
+        }
+        AvahiStringList *next = avahi_string_list_add(m->txt, buf);
+        if (!next) goto fail;
+        m->txt = next;
+    }
+
+    m->poll = avahi_threaded_poll_new();
+    if (!m->poll) goto fail;
+
+    int err = 0;
+    m->client = avahi_client_new(avahi_threaded_poll_get(m->poll),
+                                 0, client_cb, m, &err);
+    if (!m->client) {
+        fprintf(stderr, "mdns: avahi_client_new failed: %s\n",
+                avahi_strerror(err));
+        goto fail;
+    }
+
+    if (avahi_threaded_poll_start(m->poll) < 0) {
+        fprintf(stderr, "mdns: threaded_poll_start failed\n");
+        goto fail;
+    }
+
+    return m;
+
+fail:
+    aoether_mdns_close(m);
+    return NULL;
+}
+
+void aoether_mdns_close(struct aoether_mdns *m)
+{
+    if (!m) return;
+    if (m->poll) avahi_threaded_poll_stop(m->poll);
+    if (m->client) avahi_client_free(m->client);
+    if (m->poll) avahi_threaded_poll_free(m->poll);
+    if (m->txt) avahi_string_list_free(m->txt);
+    free(m->service_type);
+    free(m->instance_name);
+    free(m);
+}
+
+int aoether_mdns_available(void) { return 1; }
+
+#else  /* !AOETHER_HAVE_AVAHI */
+
+#include <stdio.h>
+
+struct aoether_mdns *aoether_mdns_publish(const char *service_type,
+                                          const char *instance_name,
+                                          uint16_t port,
+                                          const struct aoether_mdns_txt *txt,
+                                          size_t txt_count)
+{
+    (void)service_type; (void)instance_name; (void)port; (void)txt; (void)txt_count;
+    fprintf(stderr, "mdns: not compiled in (install libavahi-client-dev and rebuild)\n");
+    return NULL;
+}
+
+void aoether_mdns_close(struct aoether_mdns *m) { (void)m; }
+
+int aoether_mdns_available(void) { return 0; }
+
+#endif

--- a/common/mdns.h
+++ b/common/mdns.h
@@ -1,0 +1,41 @@
+#pragma once
+
+/* Small wrapper around Avahi client for publishing one mDNS-SD service.
+ *
+ * Used by AOEther M7 Phase A to let receivers advertise themselves on the
+ * local network with their DAC capabilities in TXT records, so talkers
+ * (or operators running `avahi-browse -r _aoether._udp`) can discover them
+ * without static IP/MAC configuration.
+ *
+ * The publish call is best-effort: if libavahi is not available at build
+ * time, or avahi-daemon is not running at runtime, the call returns NULL
+ * and the caller continues without an advertisement. Discovery is a
+ * convenience layer, never part of the data path.
+ *
+ * Threading: the Avahi backend runs its own thread internally; callers do
+ * not integrate it into their poll loop.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct aoether_mdns;
+
+struct aoether_mdns_txt {
+    const char *key;
+    const char *value;   /* NULL is allowed and means the key is boolean */
+};
+
+/* Publish one service. Returns NULL on failure (avahi unavailable, daemon
+ * down, name collision, etc.); in that case the caller should log and
+ * continue — mDNS publication is optional. */
+struct aoether_mdns *aoether_mdns_publish(const char *service_type,
+                                          const char *instance_name,
+                                          uint16_t port,
+                                          const struct aoether_mdns_txt *txt,
+                                          size_t txt_count);
+
+void aoether_mdns_close(struct aoether_mdns *m);
+
+/* True if this binary was built with Avahi support. Useful for banners. */
+int aoether_mdns_available(void);

--- a/docs/design.md
+++ b/docs/design.md
@@ -431,15 +431,43 @@ M3 is split into two sub-phases because it's mostly hardware work:
 
 **Time estimate:** 2 weekends for wire-format plumbing + silence-path smoke test (done). DAC-matrix build-out (M8 overlap) and U32_BE follow-up add incrementally.
 
-### M7 — AVDECC, discovery, and MCU receiver track kickoff
+### M7 — Discovery, AVDECC, and MCU receiver track kickoff
 
-**Goal:** Discovery and control plane across all transport modes. Start the Tier 3 MCU receiver track in parallel.
+**Goal:** Discovery and control plane across all transport modes. Start the Tier 3 MCU receiver track in parallel. Large milestone, split into three phases that ship independently.
+
+#### Phase A — mDNS-SD discovery (in progress)
+
+Simple-home-network path: receivers publish themselves as `_aoether._udp` with TXT records describing their DAC capabilities (channels, rate, format, transport, port). Talkers and operators discover receivers without static MAC/IP configuration.
+
+- `common/mdns.c` wraps Avahi's `avahi_threaded_poll` API. Graceful no-op fallback when libavahi-client isn't present at build time, so the data path keeps working on minimal systems.
+- Receiver: `--announce [--name NAME]` flags publish on startup.
+- `tools/aoether-browse` is a small helper that resolves the service type and prints a one-line summary per receiver; `avahi-browse -r _aoether._udp` works as a manual alternative.
+- TXT schema and recipe live in [`docs/recipe-discovery.md`](recipe-discovery.md).
+
+**Out of scope for Phase A:**
+- Talker-side auto-select (picking a receiver from the discovered set). A `--dest=mdns:NAME` shorthand is a follow-up; for now browse output is piped into the talker invocation manually.
+- Expressing full capability matrices in TXT records (e.g. "PCM up to 192 kHz **and** DSD256"). Each run publishes one concrete configuration; capability matrices are Phase B's job.
+
+#### Phase B — AVDECC entity model
+
+Milan-controller path. Linux side implements an IEEE 1722.1 entity model (ADP advertising, ACMP CONNECT_TX/RX, AECP AEM READ_DESCRIPTOR) sufficient for Hive and other Milan controllers to discover AOEther endpoints and establish streams. Capability descriptors are populated from DAC-level discovery (supported rates, channel counts, whether the DAC supports Milan-compatible formats). Interop target is Hive's "Connect" workflow working end-to-end against AOEther listeners and talkers without manual stream ID / MAC entry.
 
 **Deliverables:**
-- Linux side: AVDECC entity model for L2/AVTP deployments (Hive-compatible). mDNS-SD for IP deployments. Capability records populated from DAC discovery. Stream setup negotiates format + transport end-to-end.
-- MCU side: RT1170 USB host stack enumerates a target DAC and streams stereo PCM from Ethernet. L2 mode first; IP mode added opportunistically.
+- `common/avdecc.{h,c}` — ADP / ACMP / AECP PDU encode/decode, descriptor tables, state machine for the listener and talker roles.
+- Receiver: `--avdecc` flag starts the entity responder. `READ_DESCRIPTOR(ENTITY, CONFIGURATION, STREAM_INPUT, AUDIO_UNIT, LOCALE, STRINGS)` gets Hive to render the entity correctly.
+- Talker: matching responder on the talker side so streams advertised in AOEther show up in Hive's talker list.
+- `docs/recipe-avdecc.md` with Hive bring-up, screenshots, and troubleshooting.
 
-**Time estimate:** 6–8 weekends across tracks.
+**Out of scope for Phase B (tracked as follow-ups):**
+- MSRP stream reservation. Deferred to the TSN hardening track.
+- gPTP-disciplined `avtp_timestamp`. Requires M3 Phase B hardware PTP; drops in once both are merged.
+- AECP AEM checksums beyond what Hive requires for basic display.
+
+#### Phase C — MCU receiver track kickoff
+
+RT1170 USB host stack enumerates a target DAC and streams stereo PCM from Ethernet. L2 mode first; IP mode added opportunistically. Shares `common/` with the Linux binaries (packet framing, AAF header, mDNS stub). Needs real NXP MIMXRT1170-EVKB hardware; deliverable is a blinking-LED-plus-stereo-PCM firmware image and a bring-up doc, not a polished streamer — that arrives in M8.
+
+**Time estimate:** Phase A: 1 weekend (shipped). Phase B: 3–4 weekends. Phase C: 2–3 weekends once EVKB arrives.
 
 ### M8 — Scale, soak, DSD1024/2048, packaging
 

--- a/docs/recipe-discovery.md
+++ b/docs/recipe-discovery.md
@@ -1,0 +1,121 @@
+# Recipe: mDNS-SD discovery
+
+**M7 Phase A.** Receivers advertise themselves on the local network via mDNS-SD so talkers (and operators) don't need to hardcode MAC addresses or IP addresses.
+
+Discovery is a convenience layer, never part of the data path.
+The receiver still works fine with `--announce` off; conversely, the talker can still be driven from a static `--dest-mac` / `--dest-ip` even when the receiver is advertising.
+Phase B (AVDECC for Milan controllers like Hive) is tracked separately — mDNS-SD here is the simple-home-network path.
+
+## What the receiver publishes
+
+When run with `--announce`, the receiver registers one service:
+
+- **Service type:** `_aoether._udp`
+- **Instance name:** `--name NAME` if given, else the machine's hostname. Avahi auto-appends " #2", " #3" on name collisions.
+- **Port:** the `--port N` value (8805 default). Meaningful for `--transport ip`; still published as a reference for L2/AVTP even though those transports are MAC-addressed.
+- **TXT records:**
+
+| Key | Value | Example | Notes |
+|---|---|---|---|
+| `ver` | protocol version | `1` | Bumped on incompatible TXT-schema changes. |
+| `role` | `receiver` or `talker` | `receiver` | Future-proofing; Phase A only publishes `receiver`. |
+| `transport` | `l2`, `ip`, `avtp` | `ip` | Transport this receiver is listening on. |
+| `format` | `pcm`, `dsd64`, … | `pcm` | Matches `--format`. |
+| `channels` | integer | `2` | Matches `--channels`. |
+| `rate` | Hz or DSD byte rate | `48000` | Matches effective rate (DSD byte rate for DSD). |
+| `iface` | Linux iface name | `eth0` | Purely informational. |
+| `dac` | ALSA PCM name | `hw:CARD=D90,DEV=0` | Purely informational. |
+| `port` | UDP port | `8805` | Duplicate of SRV port; convenient for clients that only read TXT. |
+
+Multiple capabilities per receiver (e.g. "supports PCM up to 192 kHz **and** DSD256") are not expressed yet — each run publishes one concrete configuration.
+Phase B / AVDECC expresses the full capability matrix properly.
+
+## Bring-up
+
+### On the receiver
+
+```sh
+sudo apt install avahi-daemon libavahi-client-dev
+sudo systemctl enable --now avahi-daemon
+cd receiver && make
+
+sudo ./build/receiver --iface eth0 \
+                      --dac hw:CARD=Dragonfly,DEV=0 \
+                      --transport ip --port 8805 \
+                      --announce --name "living-room-dac"
+```
+
+The banner shows the published name:
+
+```
+mdns: published _aoether._udp as "living-room-dac"
+receiver: transport=ip family=v4 unicast port=8805
+          iface=eth0 dac=hw:CARD=Dragonfly,DEV=0 fmt=pcm ch=2 rate=48000 latency_us=5000 feedback=on
+```
+
+### From the talker box
+
+Browse with the bundled helper:
+
+```sh
+cd tools && make
+./build/aoether-browse
+```
+
+Typical output:
+
+```
+living-room-dac                   192.168.1.42:8805  host=pi5.local
+    ver=1
+    role=receiver
+    transport=ip
+    format=pcm
+    channels=2
+    rate=48000
+    iface=eth0
+    dac=hw:CARD=Dragonfly,DEV=0
+    port=8805
+```
+
+Or use the distro tools directly — `avahi-browse` is installed with `avahi-utils` on most distros, and `dns-sd` is built into macOS:
+
+```sh
+# Linux:
+avahi-browse -r -t _aoether._udp
+
+# macOS:
+dns-sd -B _aoether._udp
+dns-sd -L "living-room-dac" _aoether._udp
+```
+
+### Feeding discovery into the talker
+
+The talker doesn't yet auto-select discovered receivers (that's a small follow-up — likely a `--dest=mdns:NAME` shorthand).
+For now, pipe the browse output into the invocation manually, or script it:
+
+```sh
+addr=$(./tools/build/aoether-browse --timeout 2 | awk '/living-room-dac/ { print $2 }')
+ip=${addr%:*}
+sudo ./talker/build/talker --iface eno1 \
+                           --transport ip --dest-ip "$ip" \
+                           --source testtone
+```
+
+## Interaction with Milan / AVTP (Phase B)
+
+`_aoether._udp` is the AOEther-native service type, used regardless of transport.
+Milan controllers (Hive, L-Acoustics controller, etc.) do not discover via mDNS-SD — they use AVDECC over L2.
+Phase B will add an AVDECC entity responder so Hive sees AOEther receivers without any mDNS-SD machinery.
+`--announce` stays useful even after Phase B lands: it's the right discovery surface for Mode 3 (IP/UDP) deployments and for any non-Milan client.
+
+## Troubleshooting
+
+**"mdns: not compiled in"** — rebuild after `apt install libavahi-client-dev`; the Makefile detects the library via `pkg-config` and falls back to a no-op stub otherwise.
+
+**"mdns: avahi_client_new failed: Daemon not running"** — `systemctl start avahi-daemon` on the receiver box.
+
+**`avahi-browse` shows nothing but the receiver says "published"** — avahi needs to reach the querying host on UDP 5353. Check firewalls, and remember mDNS doesn't cross subnets without an mDNS reflector.
+
+**TXT record values with commas / spaces** — none of Phase A's keys need escaping. If we ever add comma-joined lists (e.g. `rates=44100,48000,96000`) they are valid DNS-TXT payload as-is, but be careful with shell quoting when scripting against them.
+
+**Multiple receivers with the same DAC name** — Avahi appends " #2" automatically. If you want stable names, pass `--name` explicitly on each box.

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -411,3 +411,9 @@ A1 01 01 00 00 01 03 E8 00 30 00 00 00 00 00 00
 ```
 
 On the wire: 14-byte Ethernet header + these 16 bytes + 30 bytes of MAC padding + 4-byte FCS = 64 bytes total.
+
+## mDNS-SD discovery (M7 Phase A)
+
+Out-of-band to the wire protocol but part of the control surface. Receivers publish themselves on the local network with the service type `_aoether._udp`, a port (meaningful for Mode 3; informational for Mode 1 / Mode 2), and TXT records describing one concrete configuration.
+
+TXT schema is documented in [`recipe-discovery.md`](recipe-discovery.md) — `ver`, `role`, `transport`, `format`, `channels`, `rate`, `iface`, `dac`, `port`. Schema-breaking changes bump `ver`. Multiple capabilities per receiver are expressed via AVDECC (M7 Phase B), not mDNS.

--- a/receiver/Makefile
+++ b/receiver/Makefile
@@ -7,12 +7,23 @@ INCLUDES  := -Isrc -I../common
 SRCS      := \
     src/receiver.c \
     ../common/packet.c \
-    ../common/avtp.c
+    ../common/avtp.c \
+    ../common/mdns.c
+
+# mDNS-SD advertisement (M7 Phase A) is optional. If pkg-config finds
+# avahi-client at build time we compile the real publisher; otherwise
+# `--announce` prints a "rebuild with libavahi" message and the data path
+# still works exactly as before.
+HAVE_AVAHI := $(shell pkg-config --exists avahi-client && echo 1)
+ifeq ($(HAVE_AVAHI),1)
+CFLAGS  += -DAOETHER_HAVE_AVAHI $(shell pkg-config --cflags avahi-client)
+LDLIBS  += $(shell pkg-config --libs avahi-client)
+endif
 
 .PHONY: all clean
 all: $(BUILD)/receiver
 
-$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h | $(BUILD)
+$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h ../common/mdns.h | $(BUILD)
 	$(CC) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -40,6 +40,8 @@ Flags:
 - `--format FMT` — `pcm` (default) or `dsd64 | dsd128 | dsd256 | dsd512` (M6). DSD uses `SND_PCM_FORMAT_DSD_U8`; DACs requiring `DSD_U32_BE` / `DSD_U16_LE` are a follow-up. See [`docs/recipe-dsd.md`](../docs/recipe-dsd.md).
 - `--latency-us N` — ALSA period latency hint (default 5000 µs). Generous on purpose; the Mode C loop corrects ppm-scale drift slowly and the buffer also absorbs talker-side `timerfd` jitter.
 - `--no-feedback` — disable FEEDBACK emission. **Diagnostic only** — the positive control for the soak test (design.md §M1 test 7): with feedback off, the stream is expected to drift and xrun within minutes, confirming Mode C is doing real work when it's on.
+- `--announce` — publish this receiver via mDNS-SD (`_aoether._udp`) so talkers and `avahi-browse` can discover it without static MAC/IP configuration (M7 Phase A). Requires `libavahi-client-dev` at build time and `avahi-daemon` at runtime; without them the data path still works and the flag prints a "not compiled in" message. See [`docs/recipe-discovery.md`](../docs/recipe-discovery.md).
+- `--name NAME` — instance name to publish (default: hostname). Avahi appends " #2", " #3" on collisions.
 
 Needs `CAP_NET_RAW` for the raw sockets in L2 mode; easiest path is `sudo`. IP mode doesn't require root for port 8805.
 

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -1,4 +1,5 @@
 #include "avtp.h"
+#include "mdns.h"
 #include "packet.h"
 
 #include <alsa/asoundlib.h>
@@ -121,7 +122,10 @@ static void usage(const char *prog)
         "  --rate HZ            PCM only: 44100|48000|88200|96000|176400|192000\n"
         "                       (default %d; ignored for DSD — rate is implied by --format)\n"
         "  --latency-us N       ALSA period latency hint (default %d)\n"
-        "  --no-feedback        do not emit Mode C FEEDBACK frames (diagnostic)\n",
+        "  --no-feedback        do not emit Mode C FEEDBACK frames (diagnostic)\n"
+        "  --announce           publish this receiver via mDNS-SD (_aoether._udp)\n"
+        "                       so talkers and avahi-browse can discover it\n"
+        "  --name NAME          instance name to publish (default: hostname)\n",
         prog, DEFAULT_UDP_PORT, DEFAULT_CHANNELS, DEFAULT_RATE_HZ, DEFAULT_LATENCY_US);
 }
 
@@ -161,6 +165,8 @@ int main(int argc, char **argv)
     int feedback_enabled = 1;
     enum transport_mode transport = TRANSPORT_L2;
     int udp_port = DEFAULT_UDP_PORT;
+    int announce = 0;
+    const char *announce_name = NULL;
 
     static const struct option opts[] = {
         { "iface",       required_argument, 0, 'i' },
@@ -173,11 +179,13 @@ int main(int argc, char **argv)
         { "format",      required_argument, 0, 'F' },
         { "latency-us",  required_argument, 0, 'l' },
         { "no-feedback", no_argument,       0, 'n' },
+        { "announce",    no_argument,       0, 'A' },
+        { "name",        required_argument, 0, 'N' },
         { "help",        no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:F:l:nh", opts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "i:d:T:P:G:C:r:F:l:nAN:h", opts, NULL)) != -1) {
         switch (c) {
         case 'i': iface = optarg; break;
         case 'd': dac = optarg; break;
@@ -194,6 +202,8 @@ int main(int argc, char **argv)
         case 'F': format_s = optarg; break;
         case 'l': latency_us = atoi(optarg); break;
         case 'n': feedback_enabled = 0; break;
+        case 'A': announce = 1; break;
+        case 'N': announce_name = optarg; break;
         case 'h': usage(argv[0]); return 0;
         default:  usage(argv[0]); return 2;
         }
@@ -410,6 +420,50 @@ int main(int argc, char **argv)
                 group_s ? group_s : "",
                 iface, dac, fmt.name, channels, rate_hz, latency_us,
                 feedback_enabled ? "on" : "off");
+    }
+
+    /* mDNS-SD: announce this receiver and its DAC capabilities so talkers
+     * (and avahi-browse) can discover it without static configuration.
+     * See docs/recipe-discovery.md. Publication is best-effort; if avahi
+     * isn't present we log and carry on. */
+    struct aoether_mdns *mdns = NULL;
+    if (announce) {
+        char hostname[128];
+        if (!announce_name) {
+            if (gethostname(hostname, sizeof(hostname)) == 0) {
+                hostname[sizeof(hostname) - 1] = 0;
+                announce_name = hostname;
+            } else {
+                announce_name = "aoether-receiver";
+            }
+        }
+        char ch_s[8], rate_s[16], port_s[8];
+        snprintf(ch_s,   sizeof(ch_s),   "%d", channels);
+        snprintf(rate_s, sizeof(rate_s), "%d", rate_hz);
+        snprintf(port_s, sizeof(port_s), "%d", udp_port);
+        const char *transport_s =
+            transport == TRANSPORT_L2   ? "l2"   :
+            transport == TRANSPORT_AVTP ? "avtp" : "ip";
+        struct aoether_mdns_txt txt[] = {
+            { "ver",       "1" },
+            { "role",      "receiver" },
+            { "transport", transport_s },
+            { "format",    fmt.name },
+            { "channels",  ch_s },
+            { "rate",      rate_s },
+            { "iface",     iface },
+            { "dac",       dac },
+            { "port",      port_s },
+        };
+        mdns = aoether_mdns_publish("_aoether._udp",
+                                    announce_name,
+                                    (uint16_t)udp_port,
+                                    txt,
+                                    sizeof(txt) / sizeof(txt[0]));
+        if (!mdns) {
+            fprintf(stderr,
+                    "receiver: mDNS-SD publication failed (continuing without announce)\n");
+        }
     }
 
     /* Data-path buffer and counters. */
@@ -660,5 +714,6 @@ check_feedback:
     snd_pcm_close(pcm);
     if (ctl_sock != data_sock) close(ctl_sock);
     close(data_sock);
+    aoether_mdns_close(mdns);
     return 0;
 }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,28 @@
+CC      ?= cc
+CFLAGS  ?= -O2 -Wall -Wextra -Wpedantic -std=c11 -D_GNU_SOURCE
+
+BUILD   := build
+INCLUDES := -I../common
+
+# mDNS-SD via Avahi is optional. If pkg-config finds avahi-client, compile
+# the real helper; otherwise the binary prints a "rebuild with libavahi"
+# message at runtime.
+HAVE_AVAHI := $(shell pkg-config --exists avahi-client && echo 1)
+ifeq ($(HAVE_AVAHI),1)
+CFLAGS  += -DAOETHER_HAVE_AVAHI $(shell pkg-config --cflags avahi-client)
+LDLIBS  += $(shell pkg-config --libs avahi-client)
+endif
+
+SRCS := src/aoether_browse.c
+
+.PHONY: all clean
+all: $(BUILD)/aoether-browse
+
+$(BUILD)/aoether-browse: $(SRCS) | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
+
+$(BUILD):
+	@mkdir -p $(BUILD)
+
+clean:
+	rm -rf $(BUILD)

--- a/tools/src/aoether_browse.c
+++ b/tools/src/aoether_browse.c
@@ -1,0 +1,180 @@
+/* aoether-browse — discover AOEther receivers on the local network.
+ *
+ * Browses the mDNS-SD service type `_aoether._udp`, resolves each hit, and
+ * prints a one-line summary per receiver (name, address:port, and the
+ * TXT-record capabilities published by the receiver's `--announce`).
+ *
+ * Runs for --timeout seconds (default 3), then exits. Useful on its own
+ * (`aoether-browse`) or from shell scripts that pre-populate a talker
+ * invocation.
+ *
+ * For manual use from any Linux box you can instead run:
+ *   avahi-browse -r -t _aoether._udp
+ *
+ * This helper exists because Avahi's tools vary across distros and
+ * scripting against `avahi-browse`'s text output is brittle.
+ */
+
+#ifdef AOETHER_HAVE_AVAHI
+
+#include <avahi-client/client.h>
+#include <avahi-client/lookup.h>
+#include <avahi-common/error.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/simple-watch.h>
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static AvahiSimplePoll *g_poll;
+
+static void resolve_cb(AvahiServiceResolver *r,
+                       AvahiIfIndex interface,
+                       AvahiProtocol protocol,
+                       AvahiResolverEvent event,
+                       const char *name,
+                       const char *type,
+                       const char *domain,
+                       const char *host_name,
+                       const AvahiAddress *address,
+                       uint16_t port,
+                       AvahiStringList *txt,
+                       AvahiLookupResultFlags flags,
+                       void *userdata)
+{
+    (void)interface; (void)protocol; (void)type; (void)domain;
+    (void)flags; (void)userdata;
+
+    if (event == AVAHI_RESOLVER_FAILURE) {
+        fprintf(stderr, "resolve %s failed\n", name);
+        avahi_service_resolver_free(r);
+        return;
+    }
+
+    char addr[AVAHI_ADDRESS_STR_MAX];
+    avahi_address_snprint(addr, sizeof(addr), address);
+    printf("%-32s  %s:%u  host=%s\n", name, addr, port, host_name);
+
+    for (AvahiStringList *t = txt; t; t = avahi_string_list_get_next(t)) {
+        char *key = NULL, *val = NULL;
+        size_t val_size = 0;
+        if (avahi_string_list_get_pair(t, &key, &val, &val_size) == 0) {
+            printf("    %s=%s\n", key, val ? val : "");
+            avahi_free(key);
+            avahi_free(val);
+        }
+    }
+
+    avahi_service_resolver_free(r);
+}
+
+static void browse_cb(AvahiServiceBrowser *b,
+                      AvahiIfIndex interface,
+                      AvahiProtocol protocol,
+                      AvahiBrowserEvent event,
+                      const char *name,
+                      const char *type,
+                      const char *domain,
+                      AvahiLookupResultFlags flags,
+                      void *userdata)
+{
+    (void)b; (void)flags;
+    AvahiClient *client = userdata;
+
+    switch (event) {
+    case AVAHI_BROWSER_NEW:
+        avahi_service_resolver_new(client, interface, protocol,
+                                   name, type, domain,
+                                   AVAHI_PROTO_UNSPEC, 0,
+                                   resolve_cb, client);
+        break;
+    case AVAHI_BROWSER_FAILURE:
+        fprintf(stderr, "browser failure: %s\n",
+                avahi_strerror(avahi_client_errno(client)));
+        avahi_simple_poll_quit(g_poll);
+        break;
+    case AVAHI_BROWSER_ALL_FOR_NOW:
+    case AVAHI_BROWSER_CACHE_EXHAUSTED:
+    case AVAHI_BROWSER_REMOVE:
+    default:
+        break;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int timeout_ms = 3000;
+    const char *service = "_aoether._udp";
+
+    static const struct option opts[] = {
+        { "timeout", required_argument, 0, 't' },
+        { "service", required_argument, 0, 's' },
+        { "help",    no_argument,       0, 'h' },
+        { 0, 0, 0, 0 },
+    };
+    int c;
+    while ((c = getopt_long(argc, argv, "t:s:h", opts, NULL)) != -1) {
+        switch (c) {
+        case 't': timeout_ms = atoi(optarg) * 1000; break;
+        case 's': service = optarg; break;
+        case 'h':
+        default:
+            fprintf(stderr,
+                    "usage: %s [--timeout S] [--service _aoether._udp]\n",
+                    argv[0]);
+            return c == 'h' ? 0 : 2;
+        }
+    }
+
+    g_poll = avahi_simple_poll_new();
+    if (!g_poll) return 1;
+
+    int err = 0;
+    AvahiClient *client = avahi_client_new(avahi_simple_poll_get(g_poll),
+                                           0, NULL, NULL, &err);
+    if (!client) {
+        fprintf(stderr, "avahi_client_new: %s\n", avahi_strerror(err));
+        return 1;
+    }
+
+    AvahiServiceBrowser *br =
+        avahi_service_browser_new(client, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC,
+                                  service, NULL, 0, browse_cb, client);
+    if (!br) {
+        fprintf(stderr, "browser_new: %s\n",
+                avahi_strerror(avahi_client_errno(client)));
+        return 1;
+    }
+
+    struct timespec start, now;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (;;) {
+        if (avahi_simple_poll_iterate(g_poll, 100) != 0) break;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        long elapsed_ms = (now.tv_sec - start.tv_sec) * 1000 +
+                          (now.tv_nsec - start.tv_nsec) / 1000000;
+        if (elapsed_ms >= timeout_ms) break;
+    }
+
+    avahi_service_browser_free(br);
+    avahi_client_free(client);
+    avahi_simple_poll_free(g_poll);
+    return 0;
+}
+
+#else  /* !AOETHER_HAVE_AVAHI */
+
+#include <stdio.h>
+int main(void)
+{
+    fprintf(stderr,
+            "aoether-browse: built without libavahi-client.\n"
+            "Install libavahi-client-dev and rebuild, or use `avahi-browse -r _aoether._udp`.\n");
+    return 1;
+}
+
+#endif


### PR DESCRIPTION
Receivers publish themselves on the local network as `_aoether._udp` with TXT records describing one concrete stream configuration (role, transport, format, channels, rate, iface, dac, port). Talkers and operators discover them without static MAC/IP configuration.

- common/mdns.{h,c}: thin wrapper over Avahi's threaded_poll API. Publication is best-effort; if libavahi-client is not present at build time a no-op stub is compiled in instead, so the data path keeps working on minimal systems.
- receiver: new --announce and --name flags. Publication happens after ALSA opens so the advertised configuration reflects what the receiver can actually play.
- tools/aoether-browse: small helper that browses, resolves, and prints discovered receivers. `avahi-browse -r _aoether._udp` and `dns-sd -B _aoether._udp` (macOS) work as manual alternatives.
- docs/recipe-discovery.md: operator recipe, TXT schema, and troubleshooting.
- design.md: M7 now explicitly split into Phase A (mDNS-SD, this commit), Phase B (AVDECC for Milan controllers), Phase C (MCU receiver track kickoff). Phase A is code-complete; B and C are scoped but not started.

Out of scope: talker-side auto-select (a future `--dest=mdns:NAME` shorthand), capability matrices in TXT records (AVDECC job), AVDECC entity responder.