### PR TITLE
Add DSF file reader as a talker source (M6 follow-up)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -423,7 +423,7 @@ M3 is split into two sub-phases because it's mostly hardware work:
 
 **Out of scope for M6 (tracked as follow-ups):**
 - DoP encoder on the talker (format codes `0x20..0x23`). The wire format already reserves them; wiring up a PCM-wrapped-DSD source needs a small DoP modulator which is straightforward but didn't make M6's code budget.
-- DSF / DFF file reader. `.dsf` is simple (Sony spec, LSB-first per-byte bit order — inverse of our wire format, so a bit-reverse step is needed on read) but the per-DAC quirk testing it enables is better concentrated in M8 alongside DSD512+.
+- DSF file reader shipped as a post-M6 follow-up (`talker/src/audio_source_dsf.c`; see `docs/recipe-dsd.md` §"Step 3"). Handles the Sony spec's block-per-channel interleave and LSB-first per-byte bit order (AOE wire is MSB-first, so each byte is bit-reversed on read). DFF remains deferred — the per-DAC quirk testing it enables is better concentrated in M8 alongside DSD512+.
 - DSD512 / DSD1024 / DSD2048. DSD512 overflows the u8 `payload_count` field; DSD1024 stereo additionally breaks the 1500-byte MTU. Packet splitting + `last-in-group` reassembly arrives in M8.
 
 **Key note:** This milestone is dramatically simpler than it was in earlier drafts because `snd_usb_audio` already does the hard work. Our code is about wire format and format selection, not kernel drivers.

--- a/docs/recipe-dsd.md
+++ b/docs/recipe-dsd.md
@@ -18,7 +18,7 @@ For the wire-format byte layout see [`wire-format.md`](wire-format.md) §"Native
 ## What does NOT work yet
 
 - **DSD512 and higher.** DSD512 stereo needs ~353 bytes per channel per USB microframe, which overflows the wire format's `u8 payload_count` field (max 255). DSD1024 stereo at ~705 bytes per channel additionally breaks the 1500-byte MTU. Both land in M8 with the packet-splitting work and the `last-in-group` reassembly flag.
-- **Only synthesized silence.** The talker's built-in `--source dsdsilence` emits the DSD idle pattern (`0x69`) on every channel. On a real DAC this plays as silence, which is exactly what's needed to verify the wire path and ALSA format selection work. Playing a real DSD file requires a `.dsf` / `.dff` reader (deferred to M8 — per-DAC quirk testing concentrates there).
+- **DFF (.dff) file reading.** AOEther ships a DSF reader (Sony `.dsf`) but not a DSF-Interchange-File-Format reader. DFF is a straightforward follow-up — its bit order already matches the AOE wire format (MSB-first) — but is deferred alongside the per-DAC quirk matrix.
 - **DoP mode is not wired up.** The wire format reserves codes `0x20..0x23` for DoP (PCM s24le-3 with 0x05 / 0xFA marker bytes at inflated rates), and talker/receiver framework would accept them, but the talker has no DoP encoder source yet. If a DAC works only through DoP and not native DSD, use PCM mode for now and wait for the DoP encoder.
 
 ## Step 1 — smoke test: talker → receiver → DSD DAC
@@ -92,11 +92,26 @@ These are typical — trust `/proc/asound` over this table.
 
 ## Step 3 — playing real DSD content
 
-Not supported in M6. The bridge-via-snd-aloop pattern used for PCM (`docs/recipe-roon.md`, `docs/recipe-capture.md`) won't work for DSD directly either, because `snd-aloop` is PCM-only.
+The talker accepts Sony DSF (`.dsf`) files via `--source dsf --file PATH.dsf`. Point `--format` at the file's DSD rate and `--channels` at its channel count; the file is validated at startup and loops when it hits EOF (same semantics as the WAV source).
 
-For now, the test workflow is silence-in / silence-out to verify protocol correctness. Real DSD playback arrives in M8 together with DSD1024/2048, a DSF file reader, and the per-DAC quirk matrix in [`dacs.md`](dacs.md).
+```sh
+# DSD64 stereo .dsf, Mode 1 transport:
+sudo ./build/talker --iface eno1 --dest-mac <receiver-iface-MAC> \
+                    --source dsf --file track.dsf \
+                    --format dsd64 --channels 2
+```
 
-If you're impatient: HQPlayer's NAA remains the audiophile-grade path for DSD file playback today. AOEther's DSD differentiation is that it's open-source and the control plane can be extended (PTP, multichannel, AVDECC in M7).
+What the reader does internally:
+
+- Parses the DSF header, `fmt ` chunk, and `data` chunk per the Sony DSF 1.01 spec.
+- Deinterleaves the file's 4096-byte-per-channel blocks into AOE's byte-granular channel interleave on every `read()`.
+- Bit-reverses each byte when the file is stored LSB-first (`bits_per_sample=1`, the usual case) so the wire stream comes out MSB-first.
+- Validates the file's declared channels and sampling frequency against the configured `--format` / `--channels`. Mismatches abort at startup — AOEther never resamples.
+- Rejects DSD512+ DSF content with a clear error pointing at M8 (packet-splitting extension needed).
+
+The bridge-via-snd-aloop pattern used for PCM (`docs/recipe-roon.md`, `docs/recipe-capture.md`) still does not work for DSD streams because `snd-aloop` is PCM-only. The DSF reader is the intended path for local DSD file playback today.
+
+DFF (`.dff`) files are a tracked follow-up; HQPlayer's NAA remains a reasonable external option for DFF or for content above DSD256 until M8 lands.
 
 ## Step 4 — DSD + IP/UDP
 

--- a/talker/Makefile
+++ b/talker/Makefile
@@ -11,6 +11,7 @@ SRCS      := \
     src/audio_source_wav.c \
     src/audio_source_alsa.c \
     src/audio_source_dsd.c \
+    src/audio_source_dsf.c \
     ../common/packet.c \
     ../common/avtp.c \
     ../common/avdecc.c

--- a/talker/README.md
+++ b/talker/README.md
@@ -27,8 +27,8 @@ Flags:
 - `--dest-mac AA:BB:CC:DD:EE:FF` — receiver's MAC (required with `--transport l2` or `--transport avtp`; for AVTP this is typically the listener's stream destination MAC, often a Milan-range multicast like `91:E0:F0:00:01:00`).
 - `--dest-ip IP` — destination IPv4 or IPv6 literal (required with `--transport ip`). Multicast groups (224.0.0.0/4 or ff00::/8) are auto-detected.
 - `--port N` — UDP port (IP mode only, default 8805).
-- `--source testtone|wav|alsa|dsdsilence` — default `testtone` for PCM, `dsdsilence` for DSD. `testtone` is 1 kHz sine at −6 dBFS. `dsdsilence` emits the DSD idle pattern (`0x69`) — silent on a real DAC, used to verify the wire path.
-- `--file PATH` — WAV file when `--source wav`. Accepts PCM 24-bit at any of the supported channel counts and rates; the file loops.
+- `--source testtone|wav|alsa|dsdsilence|dsf` — default `testtone` for PCM, `dsdsilence` for DSD. `testtone` is 1 kHz sine at −6 dBFS. `dsdsilence` emits the DSD idle pattern (`0x69`) — silent on a real DAC, used to verify the wire path. `dsf` reads a Sony DSF file for real DSD playback.
+- `--file PATH` — WAV file when `--source wav`, or `.dsf` file when `--source dsf`. Files loop. DSF files are validated against `--format` / `--channels`; DSD512+ content is rejected pending the M8 packet-splitting extension.
 - `--capture hw:CARD=...` — ALSA PCM name when `--source alsa`. Point at one half of a `snd-aloop` pair to receive from Roon/UPnP/PipeWire; see `docs/recipe-*.md`.
 - `--channels N` — channel count (1..64, default 2). Receiver must match.
 - `--rate HZ` — PCM only: one of 44100, 48000, 88200, 96000, 176400, 192000 (default 48000). Ignored for DSD — rate is implied by `--format`.

--- a/talker/src/audio_source.h
+++ b/talker/src/audio_source.h
@@ -19,6 +19,15 @@ struct audio_source *audio_source_alsa_open(const char *pcm_name, int channels, 
  * DSD64 it's 352800, for DSD256 it's 1411200. `read()` returns the idle
  * pattern (`AOE_DSD_IDLE_BYTE`) interleaved across channels — acoustically
  * silent on a real DAC, but exercises the full wire-format and ALSA
- * native-DSD path. A real DSF/DFF file reader is deferred to M8 alongside
- * DSD1024/2048 because it ties into the same per-DAC-quirk matrix. */
+ * native-DSD path. */
 struct audio_source *audio_source_dsd_silence_open(int channels, int dsd_byte_rate);
+
+/* DSF file reader. Opens a Sony DSF (DSD Stream File) and exposes its
+ * contents through the standard audio_source interface. The reader
+ * deinterleaves DSF's 4096-byte-per-channel blocks into AOE's byte-
+ * granular wire interleave and bit-reverses each byte when the file is
+ * stored LSB-first (the usual bits_per_sample=1 case). Supported rates:
+ * DSD64 / DSD128 / DSD256; DSD512+ is rejected pending the M8 packet-
+ * splitting extension. The caller must verify the DSF's reported channels
+ * and rate match --format / --channels, exactly as for the WAV source. */
+struct audio_source *audio_source_dsf_open(const char *path);

--- a/talker/src/audio_source_dsf.c
+++ b/talker/src/audio_source_dsf.c
@@ -1,0 +1,253 @@
+#include "audio_source.h"
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* DSF (Sony DSD Stream File, spec rev 1.01) reader for the talker.
+ *
+ * Two format adaptations are required to feed the AOE wire format:
+ *
+ *   1. Channel interleave. DSF stores each channel's stream as a 4096-byte
+ *      block, with one block per channel concatenated into a "frame":
+ *          [ch0 block 4096B] [ch1 block 4096B] ... [chN block]
+ *          [ch0 block 4096B] [ch1 block 4096B] ... [chN block]
+ *          ...
+ *      AOE wire wants byte-granular interleave:
+ *          ch0[0] ch1[0] ... chN[0]  ch0[1] ch1[1] ... chN[1]  ...
+ *
+ *   2. Bit order. DSF with bits-per-sample=1 stores LSB-first within each
+ *      byte; AOE wire is MSB-first (matching SND_PCM_FORMAT_DSD_U8 and the
+ *      dsdsilence source). Each byte is bit-reversed on read.
+ *      DSF files with bits-per-sample=8 are already MSB-first and pass
+ *      through untouched — rare in practice but the spec permits it.
+ *
+ * Rate validation is left to the caller: the source reports its DSD byte
+ * rate per channel in `src->rate`, and talker.c rejects mismatches against
+ * the configured --format exactly the way it does for WAV. */
+
+#define DSF_BLOCK_PER_CH       4096u
+
+struct dsf_state {
+    const uint8_t *map;
+    size_t file_len;
+    size_t data_off;        /* offset of first DSD byte in the file */
+    size_t bytes_per_ch;    /* authoritative sample count, rounded to bytes */
+    size_t pos_bc;          /* current byte offset within each channel */
+    int    channels;
+    int    reverse_bits;    /* 1 when DSF stored LSB-first (bits_per_sample=1) */
+};
+
+static uint32_t rd_le32(const uint8_t *p)
+{
+    return (uint32_t)p[0] |
+           ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+
+static uint64_t rd_le64(const uint8_t *p)
+{
+    return (uint64_t)rd_le32(p) | ((uint64_t)rd_le32(p + 4) << 32);
+}
+
+static uint8_t reverse8(uint8_t b)
+{
+    b = (uint8_t)(((b & 0xF0u) >> 4) | ((b & 0x0Fu) << 4));
+    b = (uint8_t)(((b & 0xCCu) >> 2) | ((b & 0x33u) << 2));
+    b = (uint8_t)(((b & 0xAAu) >> 1) | ((b & 0x55u) << 1));
+    return b;
+}
+
+static int dsf_read(struct audio_source *src, void *buf, size_t bytes_per_ch)
+{
+    struct dsf_state *st = src->opaque;
+    uint8_t *out = buf;
+    const size_t ch    = (size_t)st->channels;
+    const size_t block = DSF_BLOCK_PER_CH;
+    const size_t total = st->bytes_per_ch;
+
+    for (size_t i = 0; i < bytes_per_ch; i++) {
+        if (st->pos_bc >= total) {
+            st->pos_bc = 0;   /* loop like the WAV source */
+        }
+        const size_t block_idx = st->pos_bc / block;
+        const size_t in_block  = st->pos_bc % block;
+        const size_t frame_off = block_idx * ch * block;
+        for (size_t c = 0; c < ch; c++) {
+            const size_t off = st->data_off + frame_off + c * block + in_block;
+            uint8_t b = st->map[off];
+            if (st->reverse_bits) b = reverse8(b);
+            out[i * ch + c] = b;
+        }
+        st->pos_bc++;
+    }
+    return 0;
+}
+
+static void dsf_close(struct audio_source *src)
+{
+    struct dsf_state *st = src->opaque;
+    munmap((void *)st->map, st->file_len);
+    free(st);
+    free(src);
+}
+
+struct audio_source *audio_source_dsf_open(const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        perror("dsf: open");
+        return NULL;
+    }
+    struct stat sb;
+    if (fstat(fd, &sb) < 0) {
+        perror("dsf: fstat");
+        close(fd);
+        return NULL;
+    }
+    const uint8_t *map = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if (map == MAP_FAILED) {
+        perror("dsf: mmap");
+        return NULL;
+    }
+
+    /* DSD chunk (28 B) + fmt chunk (52 B) + data header (12 B) = 92 B min. */
+    if (sb.st_size < 92 || memcmp(map, "DSD ", 4) != 0) {
+        fprintf(stderr, "dsf: not a DSF file (missing 'DSD ' magic)\n");
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    const uint64_t dsd_chunk_sz = rd_le64(map + 4);
+    if (dsd_chunk_sz != 28) {
+        fprintf(stderr, "dsf: unexpected DSD chunk size %llu (expected 28)\n",
+                (unsigned long long)dsd_chunk_sz);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+
+    const uint8_t *fmt = map + 28;
+    if (memcmp(fmt, "fmt ", 4) != 0) {
+        fprintf(stderr, "dsf: missing 'fmt ' chunk after DSD header\n");
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    const uint64_t fmt_sz = rd_le64(fmt + 4);
+    if (fmt_sz != 52) {
+        fprintf(stderr, "dsf: unexpected fmt chunk size %llu (expected 52)\n",
+                (unsigned long long)fmt_sz);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+
+    const uint32_t version        = rd_le32(fmt + 12);
+    const uint32_t format_id      = rd_le32(fmt + 16);
+    const uint32_t channels       = rd_le32(fmt + 24);
+    const uint32_t sampling_freq  = rd_le32(fmt + 28);
+    const uint32_t bits_per_samp  = rd_le32(fmt + 32);
+    const uint64_t sample_count   = rd_le64(fmt + 36);
+    const uint32_t block_per_ch   = rd_le32(fmt + 44);
+
+    if (version != 1 || format_id != 0) {
+        fprintf(stderr, "dsf: unsupported DSF version=%u format_id=%u (need 1/0 = raw DSD)\n",
+                version, format_id);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    if (channels < 1 || channels > 8) {
+        fprintf(stderr, "dsf: channel count %u out of range (1..8)\n", channels);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    if (bits_per_samp != 1 && bits_per_samp != 8) {
+        fprintf(stderr, "dsf: bits_per_sample=%u (spec allows only 1 or 8)\n", bits_per_samp);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    if (block_per_ch != DSF_BLOCK_PER_CH) {
+        fprintf(stderr, "dsf: block_size_per_channel=%u (spec always 4096)\n", block_per_ch);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    /* AOEther currently carries DSD64/128/256; DSD512+ lands in M8 with
+     * the packet-splitting extension. Catch DSD512+ DSF files here rather
+     * than letting the rate-mismatch error downstream obscure what's going on. */
+    if (sampling_freq != 2822400 && sampling_freq != 5644800 &&
+        sampling_freq != 11289600) {
+        fprintf(stderr,
+                "dsf: sampling frequency %u Hz not supported "
+                "(AOEther carries DSD64/128/256 = 2822400/5644800/11289600 Hz; "
+                "DSD512+ requires the packet-splitting extension deferred to M8)\n",
+                sampling_freq);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+
+    /* data chunk */
+    const uint8_t *dat = fmt + 52;
+    if (dat + 12 > map + sb.st_size || memcmp(dat, "data", 4) != 0) {
+        fprintf(stderr, "dsf: missing 'data' chunk\n");
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    const uint64_t data_chunk_sz = rd_le64(dat + 4);
+    const size_t   data_off      = (size_t)((dat + 12) - map);
+    /* data_chunk_sz includes the 12-byte header; actual payload size is sz-12. */
+    if (data_chunk_sz < 12 || data_off + (data_chunk_sz - 12) > (size_t)sb.st_size) {
+        fprintf(stderr, "dsf: truncated data chunk\n");
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+
+    /* DSD samples are 1 bit each regardless of the bits_per_sample field —
+     * that field only describes bit order within a byte (LSB-first for 1,
+     * MSB-first for 8). Every byte of DSF payload carries exactly 8 DSD
+     * samples of one channel. */
+    const size_t bytes_per_ch = (size_t)(sample_count / 8u);
+    if (bytes_per_ch == 0) {
+        fprintf(stderr, "dsf: zero-length stream\n");
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+
+    /* The last block may be padded up to 4096 bytes even if the stream
+     * ends mid-block. Verify the file is large enough to hold every block
+     * we might index — ceil(bytes_per_ch / 4096) blocks, each channels*4096. */
+    const size_t num_blocks   = (bytes_per_ch + DSF_BLOCK_PER_CH - 1) / DSF_BLOCK_PER_CH;
+    const size_t needed_bytes = num_blocks * (size_t)channels * DSF_BLOCK_PER_CH;
+    if (data_off + needed_bytes > (size_t)sb.st_size) {
+        fprintf(stderr, "dsf: data chunk shorter than declared sample count\n");
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+
+    struct audio_source *src = calloc(1, sizeof(*src));
+    struct dsf_state    *st  = calloc(1, sizeof(*st));
+    if (!src || !st) {
+        free(src);
+        free(st);
+        munmap((void *)map, sb.st_size);
+        return NULL;
+    }
+    st->map          = map;
+    st->file_len     = sb.st_size;
+    st->data_off     = data_off;
+    st->bytes_per_ch = bytes_per_ch;
+    st->pos_bc       = 0;
+    st->channels     = (int)channels;
+    st->reverse_bits = (bits_per_samp == 1);
+
+    src->read             = dsf_read;
+    src->close            = dsf_close;
+    src->channels         = (int)channels;
+    src->rate             = (int)(sampling_freq / 8u);   /* DSD bytes/sec/channel */
+    src->bytes_per_sample = 1;
+    src->opaque           = st;
+    return src;
+}

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -194,9 +194,11 @@ static void usage(const char *prog)
         "    --dest-mac AA:BB:CC:DD:EE:FF    (required; unicast or AVTP multicast)\n"
         "\n"
         "Source:\n"
-        "  --source testtone|wav|alsa|dsdsilence   default: testtone (pcm) /\n"
-        "                                          dsdsilence when --format is DSD\n"
-        "  --file   PATH                WAV file, required with --source wav\n"
+        "  --source testtone|wav|alsa|dsdsilence|dsf\n"
+        "                               default: testtone (pcm) /\n"
+        "                               dsdsilence when --format is DSD\n"
+        "  --file   PATH                WAV file for --source wav,\n"
+        "                               DSF file for --source dsf\n"
         "  --capture hw:CARD=...        ALSA capture device, required with --source alsa\n"
         "\n"
         "Stream format:\n"
@@ -328,14 +330,21 @@ int main(int argc, char **argv)
     const int bytes_per_sample = fmt.bytes_per_sample;
     const int is_dsd = fmt.is_dsd;
 
-    /* Default source depends on format: testtone (PCM sine) or dsdsilence. */
+    /* Default source depends on format: testtone (PCM sine) or dsdsilence.
+     * --source dsf is the other DSD-capable source; everything else is PCM. */
+    const int source_is_dsd = source && (strcmp(source, "dsdsilence") == 0 ||
+                                         strcmp(source, "dsf") == 0);
     if (!source) {
         source = is_dsd ? "dsdsilence" : "testtone";
-    } else if (is_dsd && strcmp(source, "dsdsilence") != 0) {
-        fprintf(stderr, "talker: --source %s is PCM-only; native DSD requires --source dsdsilence (default)\n", source);
+    } else if (is_dsd && !source_is_dsd) {
+        fprintf(stderr,
+                "talker: --source %s is PCM-only; native DSD requires "
+                "--source dsdsilence (default) or --source dsf\n", source);
         return 2;
-    } else if (!is_dsd && strcmp(source, "dsdsilence") == 0) {
-        fprintf(stderr, "talker: --source dsdsilence requires --format dsd64|128|256|512\n");
+    } else if (!is_dsd && source_is_dsd) {
+        fprintf(stderr,
+                "talker: --source %s requires --format dsd64|dsd128|dsd256\n",
+                source);
         return 2;
     }
 
@@ -441,6 +450,22 @@ int main(int argc, char **argv)
         src = audio_source_alsa_open(capture_pcm, channels, rate_hz);
     } else if (strcmp(source, "dsdsilence") == 0) {
         src = audio_source_dsd_silence_open(channels, rate_hz);
+    } else if (strcmp(source, "dsf") == 0) {
+        if (!wav_path) {
+            fprintf(stderr, "talker: --file PATH.dsf required with --source dsf\n");
+            return 2;
+        }
+        src = audio_source_dsf_open(wav_path);
+        if (src && (src->channels != channels || src->rate != rate_hz)) {
+            fprintf(stderr,
+                    "talker: DSF file is ch=%d rate=%d (DSD bytes/s/ch); "
+                    "talker configured ch=%d rate=%d. They must match — "
+                    "use --format dsd64|dsd128|dsd256 matching the file, "
+                    "and --channels to match.\n",
+                    src->channels, src->rate, channels, rate_hz);
+            src->close(src);
+            return 2;
+        }
     } else {
         fprintf(stderr, "talker: unknown --source %s\n", source);
         return 2;


### PR DESCRIPTION
## Summary

Adds a Sony DSF (`.dsf`) file reader as a new talker source. Before this, the only DSD source was `--source dsdsilence`, which emits the idle pattern — enough to verify the wire path but not real content. This was the DSF half of the "DSF / DFF file reader" follow-up tracked against M6 (design.md:426) and called out in the announce post.

Invocation mirrors the WAV source:

```sh
sudo ./build/talker --iface eno1 --dest-mac <receiver> \
                    --source dsf --file track.dsf \
                    --format dsd64 --channels 2
```

## What's in the patch

- `talker/src/audio_source_dsf.c` — new source. Parses the DSF header / `fmt ` / `data` chunks per Sony DSF 1.01, mmaps the file, and on each `read(bytes_per_ch)`:
  - Deinterleaves DSF's 4096-byte-per-channel block layout into AOE's byte-granular channel interleave.
  - Bit-reverses each byte when the file is stored LSB-first (`bits_per_sample=1`, the common case) so the wire output matches AOE's MSB-first / `SND_PCM_FORMAT_DSD_U8` convention.
  - Rejects DSD512+ content up front with a clear error pointing at the M8 packet-splitting extension.
- Rate / channel validation in `talker.c` matches the WAV source — the DSF's declared `sampling_frequency` and `channel_count` must match `--format` and `--channels`. AOEther never resamples.
- Flag plumbing: `--source dsf` reuses `--file PATH`; help text and `talker/README.md` updated.
- Docs: `design.md` M6 follow-up list records DSF as shipped, DFF remains deferred. `recipe-dsd.md` Step 3 replaces "not supported" with the DSF recipe and keeps the DSD512+ / DFF / snd-aloop caveats.

## Not in scope

- DFF (`.dff`) reader — tracked follow-up. DFF's bit order already matches the AOE wire format, so it's a smaller patch than DSF, but the quirk-matrix testing it enables is concentrated in M8.
- DSD512+ content — still needs the packet-splitting extension tracked for M8 (the current `payload_count` field overflows past DSD256).
- DoP encoder on the talker — separate tracked M6 follow-up.

## Test plan

- [ ] `cd talker && make` on a Linux box with `libasound2-dev` builds cleanly.
- [ ] `--source dsf` with a DSD64 `.dsf` stereo file plays through to a native-DSD DAC and the DAC reports DSD64 on its front panel.
- [ ] Sanity-check the 1-byte-at-a-time block/channel indexing by inspecting the first output byte vs. the file's first data byte (MSB-first vs LSB-first for `bits_per_sample=1`).
- [ ] `--source dsf` with a DSD512+ file exits early with the "requires packet-splitting extension" error.
- [ ] `--source dsf` with `--format dsd128` but a DSD64 file exits early with the rate-mismatch error.
