### PR TITLE
Add packet splitting for DSD512+ and high-rate multichannel (M8)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -480,15 +480,26 @@ RT1170 USB host stack enumerates a target DAC and streams stereo PCM from Ethern
 
 **Goal:** Full Atmos on Linux receivers; DSD1024 / DSD2048 on MCU; move from "working prototype" to "deployable streamer."
 
-**Deliverables:**
-- Linux: 7.1.4 PCM Atmos bed, 22.2 streams, 24-hour soak, multi-receiver topologies, failure-mode docs.
-- MCU: multichannel PCM, native DSD64 through DSD1024, DSD2048 stereo. Per-DAC quirk table for major DSD DACs.
-- Linux ALSA: investigate native DSD1024/2048 exposure; propose patches if needed.
-- Deployment recipes (listening room, home theater, small venue, audiophile rack).
-- Debian packages for talker and Linux receiver; firmware image for MCU receiver.
-- Project website with docs and examples.
+Ships in pieces as sub-features land rather than as one atomic milestone. Items below are marked **[shipped]**, **[open]**, or **[hardware-blocked]** to reflect the actual state.
 
-**Time estimate:** 4–6 weekends across tracks plus calendar time for soak runs.
+**Wire-format / talker / receiver:**
+- **[shipped]** *Packet splitting for DSD512+ and high-rate multichannel PCM.* Talkers split a microframe whose per-channel `payload_count` exceeds the `u8` limit (255) or whose total payload exceeds MTU into K fragments emitted back-to-back, with per-fragment monotonic sequence numbers, shared `presentation_time` / `stream_id`, and `flags.last-in-group=1` only on the final fragment. Receivers require no group-level reassembly state — each fragment is a standalone AoE data frame that writes to ALSA unmodified, and per-fragment sequence gaps feed the existing loss counter. AVTP AAF keeps its single-packet-per-microframe constraint; fragmentation applies only to Mode 1 / Mode 3. See `wire-format.md` §"Cadence and fragmentation".
+- **[shipped]** *DSD512 / DSD1024 / DSD2048 talker and receiver support.* `--format dsd512 | dsd1024 | dsd2048` (wire codes `0x33`/`0x34`/`0x35`) is accepted on both sides now that packet splitting is in place. At stereo the wire splits DSD512 into 2 fragments/microframe, DSD1024 into 3, DSD2048 into 6. Receiver-side playback depends on the DAC's `snd_usb_audio` quirk entry — modern DSD1024 DACs are already wired up in mainline Linux; DSD2048 DAC availability is narrower but the wire path is live.
+- **[open]** *Runtime format reconfiguration via AECP `SET_STREAM_FORMAT` / `SET_SAMPLING_RATE`.* Phase B tracked this here. Needs a live ALSA reopen + fractional-accumulator retune.
+- **[open]** *DFF (`.dff`) file reader on the talker.* DFF's bit order matches the AOE wire format so no bit-reverse is needed; otherwise parallel to the DSF reader.
+- **[open]** *DoP encoder.* Format codes `0x20..0x23` are wire-reserved; wiring up a PCM-wrapped-DSD source is a modest talker-side addition.
+
+**Hardware-dependent tracks:**
+- **[hardware-blocked]** 7.1.4 PCM Atmos bed, 22.2 streams, 24-hour soak, multi-receiver topologies, failure-mode docs. Packet splitting unblocks 22.2 @ 192 kHz wire-format-wise; validation wants multichannel DAC hardware.
+- **[hardware-blocked]** MCU: multichannel PCM, native DSD64 through DSD2048. Per-DAC quirk table for major DSD DACs.
+- **[hardware-blocked]** Linux ALSA: investigate upstream quirk-entry coverage for DSD1024/2048; propose patches for any DACs mainline doesn't yet recognize.
+
+**Packaging / deployment:**
+- **[open]** Deployment recipes (listening room, home theater, small venue, audiophile rack).
+- **[open]** Debian packages for talker and Linux receiver; firmware image for MCU receiver.
+- **[open]** Project website with docs and examples.
+
+**Time estimate:** 4–6 weekends across tracks plus calendar time for soak runs. Wire-format / talker / receiver pieces land in individual PRs as they're ready; hardware-dependent validation is gated on physical access.
 
 ### M9 — Ravenna / AES67 interop
 

--- a/docs/recipe-dsd.md
+++ b/docs/recipe-dsd.md
@@ -1,12 +1,12 @@
 # Recipe: native DSD end-to-end
 
-Native DSD transport via the AOE wrapper (Mode 1 / Mode 3). PCM and DoP paths are unchanged; this recipe focuses on what M6 adds.
+Native DSD transport via the AOE wrapper (Mode 1 / Mode 3). PCM and DoP paths are unchanged.
 
-For the wire-format byte layout see [`wire-format.md`](wire-format.md) §"Native DSD".
+For the wire-format byte layout see [`wire-format.md`](wire-format.md) §"Native DSD"; for per-microframe packet splitting (used by DSD512 and higher) see §"Cadence and fragmentation".
 
-## What works in M6
+## What works
 
-- Talker accepts `--format dsd64 | dsd128 | dsd256` and emits raw DSD bits on the wire with format codes `0x30..0x32`.
+- Talker accepts `--format dsd64 | dsd128 | dsd256 | dsd512 | dsd1024 | dsd2048` and emits raw DSD bits on the wire with format codes `0x30..0x35`. DSD512 and higher are carried via per-microframe packet splitting — at stereo that's 2 fragments per microframe for DSD512, 3 for DSD1024, 6 for DSD2048 — with no receiver-side reassembly state (each fragment is a complete AoE data frame). Receiver-side ALSA support for these rates depends on the DAC's `snd_usb_audio` quirk entry; most current DSD1024 DACs are already wired up in recent Linux kernels.
 - Receiver accepts the same `--format` values plus an `--alsa-format` override to match the ALSA DSD format your DAC's `snd_usb_audio` quirk exposes:
   - `dsd_u8` (default) — wire bytes pass through 1:1, zero reorder.
   - `dsd_u16_le` / `dsd_u16_be` — receiver deinterleaves into per-channel streams and repacks at 2-byte granularity, byte-reversing within each 2-byte group for `_le`.
@@ -17,7 +17,6 @@ For the wire-format byte layout see [`wire-format.md`](wire-format.md) §"Native
 
 ## What does NOT work yet
 
-- **DSD512 and higher.** DSD512 stereo needs ~353 bytes per channel per USB microframe, which overflows the wire format's `u8 payload_count` field (max 255). DSD1024 stereo at ~705 bytes per channel additionally breaks the 1500-byte MTU. Both land in M8 with the packet-splitting work and the `last-in-group` reassembly flag.
 - **DFF (.dff) file reading.** AOEther ships a DSF reader (Sony `.dsf`) but not a DSF-Interchange-File-Format reader. DFF is a straightforward follow-up — its bit order already matches the AOE wire format (MSB-first) — but is deferred alongside the per-DAC quirk matrix.
 - **DoP mode is not wired up.** The wire format reserves codes `0x20..0x23` for DoP (PCM s24le-3 with 0x05 / 0xFA marker bytes at inflated rates), and talker/receiver framework would accept them, but the talker has no DoP encoder source yet. If a DAC works only through DoP and not native DSD, use PCM mode for now and wait for the DoP encoder.
 

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -80,7 +80,7 @@ All multi-byte integer fields are big-endian.
 | 0 | Magic | 1 | `u8` | Constant `0xA0`. Receivers MUST discard frames with any other value. |
 | 1 | Version | 1 | `u8` | Protocol version. Currently `0x01`. Receivers SHOULD discard frames with unrecognized versions. |
 | 2 | Stream ID | 2 | `u16` BE | Identifies the logical audio stream. Allocated by the talker at stream setup. |
-| 4 | Sequence Number | 4 | `u32` BE | Monotonically increasing per stream, wraps at 2^32. Receivers use this to detect loss and reorder if needed. |
+| 4 | Sequence Number | 4 | `u32` BE | Monotonically increasing **per packet** (not per microframe), wraps at 2^32. Every wire packet — including every fragment of a split microframe — takes the next sequence number. Receivers use this to detect loss. See §"Cadence" for how this interacts with fragmentation. |
 | 8 | Presentation Time | 4 | `u32` BE | Low 32 bits of the gPTP timestamp (nanoseconds) at which the first sample in this packet should be presented. Zero when no PTP is available (M1–M2). |
 | 12 | Channel Count | 1 | `u8` | Number of audio channels, 1 to 64. |
 | 13 | Format | 1 | `u8` | Format code; see table below. |
@@ -118,7 +118,7 @@ Bit 2:       marker
 Bits 3-7:    reserved (must be 0 on transmit, ignored on receive)
 ```
 
-- **last-in-group (bit 0):** Set on the final packet of a microframe when a single microframe's audio is split across multiple packets (e.g., DSD2048 stereo where 2822 bytes per microframe exceeds MTU). When split is not in use, this bit is always 1.
+- **last-in-group (bit 0):** Set on the final packet of a microframe when a single microframe's audio is split across multiple packets (see §"Cadence" for the fragmentation rules). For a non-fragmented microframe the only packet in the group is also the last in the group, so the bit is always set. Equivalently: receivers MAY treat this bit as "microframe boundary" — the packet after a `last-in-group=1` starts a new group.
 - **discontinuity (bit 1):** Set by the talker when it knows there's a gap in continuity (e.g., after a talker restart or source reconnect). Receivers use this to reset jitter buffer state without reporting an underrun.
 - **marker (bit 2):** Application-defined. May be used in future for stream-level metadata (e.g., stream start, loudness event). Receivers pass through.
 
@@ -181,13 +181,45 @@ DSD rate determines average bytes per microframe per channel:
 
 Because these are non-integer, the talker alternates packet sizes (e.g., 44 and 45 bytes) to achieve the average rate over time. The exact alternation pattern is implementation-defined; receivers MUST accept any legal `payload_count` ≥ 1.
 
-## Cadence
+## Cadence and fragmentation
 
-Packets are emitted at a nominal rate of 8000 packets per second per stream, matching the USB High-Speed microframe rate. Each packet is timed to correspond to one USB microframe on the receiver's USB output path.
+One *microframe* of audio is the nominal output of a 125 µs USB High-Speed period. The talker emits microframes at 8000 groups per second per stream, aligned to the USB microframe cadence on the receiver's USB OUT path.
 
-For payload sizes that exceed the MTU (native DSD2048 stereo is 2822 bytes per microframe, exceeding the standard 1500-byte MTU), the talker splits a single microframe's audio across multiple packets transmitted in immediate succession. The last packet in the group sets the `last-in-group` flag. All packets within a group share the same sequence number and presentation time; the receiver reassembles them into a single contiguous audio unit for the USB OUT endpoint.
+Each microframe's audio travels in one *group* of one or more data packets. A group is always at least one packet — in the common case where `payload_count × channels × bytes_per_sample + header + Ethernet overhead` fits in the MTU *and* `payload_count ≤ 255`, every group is a single packet with `last-in-group=1`.
 
-**Example:** DSD2048 stereo microframe = 2 × 1411.2 = ~2822 bytes per microframe. Split into two packets of ~1411 bytes each (payloads, plus 16-byte headers), both with the same sequence number. First packet has `last-in-group` cleared; second has it set.
+Two conditions force fragmentation:
+
+1. **`payload_count` overflow.** The field is `u8`, so DSD formats above DSD256 (which need 352.8 + bytes/channel/microframe) cannot be carried in a single packet regardless of MTU.
+2. **MTU overflow.** A microframe that would produce a payload larger than `1500 − header` bytes must be split. Very-high-rate multichannel PCM (e.g., 22.2 at 192 kHz) and DSD1024/2048 both hit this.
+
+### Fragmentation rules
+
+When a talker produces a microframe with `pc` bytes-or-samples per channel:
+
+- Compute `max_frag_pc = min(255, floor((1500 − 14 − 16) / (channels × bytes_per_sample)))` for Mode 1 / Mode 3. (For Mode 3 subtract the IP/UDP overhead additionally — AOE talkers use `floor((MTU − L3 − L4 − 16) / (channels × bytes_per_sample))`.)
+- Fragment count `K = ceil(pc / max_frag_pc)`.
+- Distribute `pc` across K fragments so no fragment exceeds `max_frag_pc`. The canonical distribution is front-loaded: the first `pc mod K` fragments get `ceil(pc/K)`; the remainder get `floor(pc/K)`. Receivers MUST NOT depend on the exact distribution, only on the invariant that each fragment's `payload_count ≥ 1` and `≤ max_frag_pc`.
+- Emit the K fragments in immediate succession. Each fragment is a complete, standalone AoE data frame:
+  - Consecutive `sequence` numbers `seq..seq+K-1` (the stream's packet counter advances once per fragment, not once per group).
+  - Same `stream_id`, `channel_count`, `format`, `presentation_time` across all fragments of the group.
+  - Per-fragment `payload_count` from the distribution above.
+  - `flags.last-in-group = 0` on fragments `0..K-2`; `= 1` on fragment `K-1`.
+- Payload for fragment `k` is a contiguous byte range from the microframe's interleaved audio, starting at sample-or-byte offset `sum(frag_pc[0..k-1])` per channel. This works because AoE's per-sample (PCM) / per-byte (DSD) channel interleave means the first N samples-or-bytes of every channel are always the leading `N × channels × bytes_per_sample` bytes of the microframe buffer.
+
+### Receiver handling
+
+No group-level reassembly state is required. Each fragment is a valid AoE data frame on its own, and writing its payload to ALSA/USB produces the correct continuous audio stream — fragments arrive in order, their per-channel byte ranges concatenate losslessly, and the sum of per-fragment `payload_count`s equals the microframe's `pc`. Receivers MAY surface `last-in-group=0` packet counts as a stat.
+
+Fragment loss is noted by the existing per-packet sequence-gap detection. A missing middle fragment produces a short write at ALSA for that microframe; a missing last fragment likewise. Both are equivalent to a tiny underrun and recovered by ALSA's own buffer management.
+
+### Examples
+
+Frame sizes below include the 14-byte Ethernet header, 16-byte AoE header, and 4-byte FCS (30 B) but are quoted inclusive of FCS to match the §"Frame size examples" table convention.
+
+- **Stereo PCM 48 kHz/24, nominal.** `pc=6` samples, payload = 36 B, fits MTU, `max_frag_pc ≥ 246` → K=1. Single packet with `last-in-group=1`.
+- **Stereo DSD512, nominal.** `pc≈353` bytes/ch. `max_frag_pc = min(255, floor(1470/2)) = 255` → K=2. Fragment 0: 177 B/ch, total payload 354 B, frame 388 B, `last-in-group=0`. Fragment 1: 176 B/ch, total payload 352 B, frame 386 B, `last-in-group=1`.
+- **Stereo DSD1024, nominal.** `pc≈706` bytes/ch. `max_frag_pc = min(255, 735) = 255` → K=3. Fragments of 236 B, 235 B, 235 B per channel. Frame sizes 506/504/504 B. Last fragment has `last-in-group=1`.
+- **Stereo DSD2048, nominal.** `pc≈1411` bytes/ch. K=6. Fragments of 236 B once then 235 B × 5 per channel. Frame sizes 506 B then 504 B × 5.
 
 ## Frame size examples
 
@@ -201,8 +233,10 @@ For payload sizes that exceed the MTU (native DSD2048 stereo is 2822 bytes per m
 | 32ch PCM 48 kHz/24 | 576 B | 610 B |
 | 32ch PCM 96 kHz/24 | 1152 B | 1186 B |
 | Stereo Native DSD64 | 88 B | 122 B |
-| Stereo Native DSD512 | 704 B | 738 B |
-| Stereo Native DSD2048 | 2822 B total → 2 pkts of 1411 B | 2 × 1445 B |
+| Stereo Native DSD256 | 352 B | 386 B |
+| Stereo Native DSD512 | 706 B total → 2 frags of ~353 B | 2 × ~387 B |
+| Stereo Native DSD1024 | 1411 B total → 3 frags of ~471 B | 3 × ~505 B |
+| Stereo Native DSD2048 | 2822 B total → 6 frags of ~471 B | 6 × ~505 B |
 
 ## Mode 2 (AVTP AAF)
 

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -33,7 +33,9 @@
 #define DSD64_BYTE_RATE   352800
 #define DSD128_BYTE_RATE  705600
 #define DSD256_BYTE_RATE  1411200
-/* DSD512 exceeds the u8 payload_count limit — needs packet splitting (M8). */
+#define DSD512_BYTE_RATE  2822400     /* M8: carried via per-microframe fragmentation. */
+#define DSD1024_BYTE_RATE 5644800
+#define DSD2048_BYTE_RATE 11289600
 
 /* Defaults match M1's previous hardcoded values. */
 #define DEFAULT_CHANNELS      2
@@ -42,8 +44,10 @@
 #define FEEDBACK_PERIOD_MS    20
 #define POLL_TIMEOUT_MS       FEEDBACK_PERIOD_MS
 
-/* Packet RX buffer: largest legal M2 frame is 12 ch × 3 B × 48 samples
- * (192 kHz microframe) = 1728 B plus 30 B header. 4 KiB is plenty. */
+/* Packet RX buffer: AOE fragmentation keeps every wire packet ≤ MTU
+ * (fragment payload ≤ 1470 B after header overhead), and AVTP keeps its
+ * single-packet-per-microframe constraint within the same MTU. 4 KiB
+ * comfortably holds one frame plus headers. */
 #define RX_BUF_BYTES     4096
 
 /* IP/UDP default port (interim; see docs/wire-format.md). */
@@ -83,9 +87,9 @@ static int parse_format(const char *s, struct stream_format *f)
         { AOE_FMT_NATIVE_DSD64,  1, DSD64_BYTE_RATE,  1, "dsd64"  },
         { AOE_FMT_NATIVE_DSD128, 1, DSD128_BYTE_RATE, 1, "dsd128" },
         { AOE_FMT_NATIVE_DSD256, 1, DSD256_BYTE_RATE, 1, "dsd256" },
-        /* DSD512 and higher need packet splitting: nominal bytes/ch per
-         * microframe exceeds the wire format's u8 payload_count field (255).
-         * Lifting that is M8 scope. */
+        { AOE_FMT_NATIVE_DSD512, 1, DSD512_BYTE_RATE, 1, "dsd512" },
+        { AOE_FMT_NATIVE_DSD1024,1, DSD1024_BYTE_RATE,1, "dsd1024" },
+        { AOE_FMT_NATIVE_DSD2048,1, DSD2048_BYTE_RATE,1, "dsd2048" },
     };
     for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
         if (strcmp(s, table[i].name) == 0) {
@@ -176,8 +180,10 @@ static void usage(const char *prog)
         "  --group IP           multicast group to join (IP mode, optional;\n"
         "                       IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8)\n"
         "  --format FMT         pcm | dsd64 | dsd128 | dsd256\n"
+        "                       | dsd512 | dsd1024 | dsd2048\n"
         "                       default pcm. AVTP transport is pcm-only.\n"
-        "                       DSD512+ needs packet splitting, deferred to M8.\n"
+        "                       DSD512+ arrives as split fragments — see\n"
+        "                       docs/wire-format.md §\"Cadence\".\n"
         "  --alsa-format FMT    ALSA sample format. Default picks from --format:\n"
         "                         pcm → pcm_s24_3le; dsd* → dsd_u8.\n"
         "                       DSD override: dsd_u8 | dsd_u16_le | dsd_u16_be |\n"

--- a/talker/src/audio_source.h
+++ b/talker/src/audio_source.h
@@ -27,7 +27,7 @@ struct audio_source *audio_source_dsd_silence_open(int channels, int dsd_byte_ra
  * deinterleaves DSF's 4096-byte-per-channel blocks into AOE's byte-
  * granular wire interleave and bit-reverses each byte when the file is
  * stored LSB-first (the usual bits_per_sample=1 case). Supported rates:
- * DSD64 / DSD128 / DSD256; DSD512+ is rejected pending the M8 packet-
- * splitting extension. The caller must verify the DSF's reported channels
- * and rate match --format / --channels, exactly as for the WAV source. */
+ * DSD64 through DSD2048 (DSD512+ via per-microframe packet splitting on the
+ * wire). The caller must verify the DSF's reported channels and rate match
+ * --format / --channels, exactly as for the WAV source. */
 struct audio_source *audio_source_dsf_open(const char *path);

--- a/talker/src/audio_source_dsf.c
+++ b/talker/src/audio_source_dsf.c
@@ -175,15 +175,16 @@ struct audio_source *audio_source_dsf_open(const char *path)
         munmap((void *)map, sb.st_size);
         return NULL;
     }
-    /* AOEther currently carries DSD64/128/256; DSD512+ lands in M8 with
-     * the packet-splitting extension. Catch DSD512+ DSF files here rather
-     * than letting the rate-mismatch error downstream obscure what's going on. */
-    if (sampling_freq != 2822400 && sampling_freq != 5644800 &&
-        sampling_freq != 11289600) {
+    /* AOEther carries DSD64/128/256/512/1024/2048 on the wire; DSD512+ is
+     * delivered as split fragments per microframe (see wire-format.md
+     * §"Cadence and fragmentation"). */
+    if (sampling_freq != 2822400  && sampling_freq != 5644800 &&
+        sampling_freq != 11289600 && sampling_freq != 22579200 &&
+        sampling_freq != 45158400 && sampling_freq != 90316800) {
         fprintf(stderr,
                 "dsf: sampling frequency %u Hz not supported "
-                "(AOEther carries DSD64/128/256 = 2822400/5644800/11289600 Hz; "
-                "DSD512+ requires the packet-splitting extension deferred to M8)\n",
+                "(AOEther accepts DSD64/128/256/512/1024/2048 = "
+                "2822400/5644800/11289600/22579200/45158400/90316800 Hz)\n",
                 sampling_freq);
         munmap((void *)map, sb.st_size);
         return NULL;

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -40,8 +40,9 @@
 #define DSD64_BYTE_RATE       352800       /* 2.8224 MHz / 8 */
 #define DSD128_BYTE_RATE      705600
 #define DSD256_BYTE_RATE      1411200
-/* DSD512 (2.8224 MB/s/ch) exceeds the wire format's u8 payload_count (255)
- * and needs packet splitting — deferred to M8. */
+#define DSD512_BYTE_RATE      2822400       /* M8: enabled by packet splitting. */
+#define DSD1024_BYTE_RATE     5644800       /* Wire: ~3 fragments/microframe stereo. */
+#define DSD2048_BYTE_RATE     11289600      /* Wire: ~6 fragments/microframe stereo. */
 
 /* Ethernet II data payload max (frame - eth header) for standard 1500 MTU. */
 #define ETH_MTU_PAYLOAD       1500
@@ -96,8 +97,9 @@ static int parse_format(const char *s, struct stream_format *f)
         { AOE_FMT_NATIVE_DSD64,   1, DSD64_BYTE_RATE,     1, "dsd64"  },
         { AOE_FMT_NATIVE_DSD128,  1, DSD128_BYTE_RATE,    1, "dsd128" },
         { AOE_FMT_NATIVE_DSD256,  1, DSD256_BYTE_RATE,    1, "dsd256" },
-        /* DSD512+ overflows the wire format's u8 payload_count field; it
-         * lands in M8 alongside the packet-splitting work. */
+        { AOE_FMT_NATIVE_DSD512,  1, DSD512_BYTE_RATE,    1, "dsd512" },
+        { AOE_FMT_NATIVE_DSD1024, 1, DSD1024_BYTE_RATE,   1, "dsd1024" },
+        { AOE_FMT_NATIVE_DSD2048, 1, DSD2048_BYTE_RATE,   1, "dsd2048" },
     };
     for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); i++) {
         if (strcmp(s, table[i].name) == 0) {
@@ -203,8 +205,10 @@ static void usage(const char *prog)
         "\n"
         "Stream format:\n"
         "  --format  FMT                pcm | dsd64 | dsd128 | dsd256\n"
-        "                               default pcm. DoP and DSD512+ are deferred\n"
-        "                               (DSD512+ needs packet splitting → M8).\n"
+        "                             | dsd512 | dsd1024 | dsd2048\n"
+        "                               default pcm. DSD512+ uses per-microframe\n"
+        "                               packet splitting (wire-format.md §Cadence).\n"
+        "                               DoP remains deferred.\n"
         "                               AVTP transport carries pcm only.\n"
         "  --channels N                 channel count (1..64, default %d)\n"
         "  --rate    HZ                 44100|48000|88200|96000|176400|192000 (default %d)\n"
@@ -343,28 +347,78 @@ int main(int argc, char **argv)
         return 2;
     } else if (!is_dsd && source_is_dsd) {
         fprintf(stderr,
-                "talker: --source %s requires --format dsd64|dsd128|dsd256\n",
+                "talker: --source %s requires --format dsd64|dsd128|dsd256|dsd512|dsd1024|dsd2048\n",
                 source);
         return 2;
     }
 
-    /* MTU check: at worst we need nominal samples-per-microframe plus a
-     * small drift margin, times channels × bytes. Plus eth (14) + protocol
-     * header (16 for AOE, 24 for AVTP-AAF). */
+    /* MTU sizing and fragmentation parameters.
+     *
+     * AOE paths (Mode 1 / Mode 3) support per-microframe fragmentation: a
+     * single microframe is split into K packets when either payload_count
+     * (u8) or the MTU would otherwise overflow. See docs/wire-format.md
+     * §"Cadence and fragmentation".
+     *
+     * AVTP AAF does not fragment — splitting an AAF stream across multiple
+     * 1722 frames per microframe breaks interop with strict Milan listeners.
+     * AAF configs that overflow MTU are rejected at startup. */
     const size_t proto_hdr_len = (transport == TRANSPORT_AVTP) ? AVTP_HDR_LEN
                                                                : AOE_HDR_LEN;
     const double nominal_spm = (double)rate_hz / 1000.0 / MICROFRAMES_PER_MS;
-    const int max_samples_per_packet = (int)(nominal_spm + 0.5) + 4;
-    const size_t max_payload = (size_t)max_samples_per_packet * channels * bytes_per_sample;
-    const size_t max_frame = sizeof(struct ether_header) + proto_hdr_len + max_payload;
-    if (max_payload + proto_hdr_len > ETH_MTU_PAYLOAD) {
+    const int max_samples_per_microframe = (int)(nominal_spm + 0.5) + 4;
+    const size_t max_microframe_payload =
+        (size_t)max_samples_per_microframe * channels * bytes_per_sample;
+
+    /* Per-fragment upper bound on payload_count: clamped by the u8 field
+     * and by the worst-case per-fragment MTU budget. Fragmentation is an
+     * AOE-only path, so we compute this for L2/IP only. */
+    int max_frag_pc = 0;
+    if (transport != TRANSPORT_AVTP) {
+        const size_t per_ch_unit = (size_t)channels * bytes_per_sample;
+        if (per_ch_unit == 0) {
+            fprintf(stderr, "talker: invalid per-channel unit\n");
+            return 2;
+        }
+        size_t mtu_budget_pc =
+            (ETH_MTU_PAYLOAD - proto_hdr_len) / per_ch_unit;
+        if (mtu_budget_pc > 255) mtu_budget_pc = 255;
+        if (mtu_budget_pc < 1) {
+            fprintf(stderr,
+                    "talker: ch=%d bps=%d — a single sample/byte per channel "
+                    "does not fit the 1500 B MTU (payload unit %zu B).\n",
+                    channels, bytes_per_sample, per_ch_unit);
+            return 2;
+        }
+        max_frag_pc = (int)mtu_budget_pc;
+    }
+
+    /* Startup MTU check. AVTP always rejects overflow; AOE only rejects the
+     * pathological "one sample doesn't fit" case handled above. */
+    if (transport == TRANSPORT_AVTP &&
+        max_microframe_payload + proto_hdr_len > ETH_MTU_PAYLOAD) {
         fprintf(stderr,
-                "talker: ch=%d rate=%d needs %zu-byte frames — exceeds 1500-byte MTU.\n"
-                "  (Packet splitting for very-high-rate multichannel is deferred; try\n"
-                "  fewer channels or a lower rate. Worst-case payload = %zu B.)\n",
-                channels, rate_hz, max_frame, max_payload);
+                "talker: ch=%d rate=%d under AVTP AAF needs %zu-byte payload "
+                "— exceeds 1500-byte MTU.\n"
+                "  AAF does not support per-microframe fragmentation (would "
+                "break Milan interop). Try --transport l2 or --transport ip, "
+                "or reduce channels / rate.\n",
+                channels, rate_hz,
+                max_microframe_payload + proto_hdr_len);
         return 2;
     }
+
+    /* Per-frame buffer sizing:
+     *   - `frame` holds one transmission unit = Ethernet header + proto
+     *     header + one fragment's payload (for AOE) or one full microframe
+     *     (for AVTP).
+     *   - `audio_buf` holds one full microframe's audio bytes, read from
+     *     the source in one `read()` call and then sliced into fragments.
+     *     AVTP reads into this too and copies once into `frame`. */
+    const size_t max_frag_payload =
+        (transport == TRANSPORT_AVTP)
+            ? max_microframe_payload
+            : ((size_t)max_frag_pc * channels * bytes_per_sample);
+    const size_t max_frame = sizeof(struct ether_header) + proto_hdr_len + max_frag_payload;
 
     /* AVTP AAF only carries integer PCM rates from the standard nsr table.
      * Reject AOE rates that don't have an AAF code. */
@@ -460,7 +514,7 @@ int main(int argc, char **argv)
             fprintf(stderr,
                     "talker: DSF file is ch=%d rate=%d (DSD bytes/s/ch); "
                     "talker configured ch=%d rate=%d. They must match — "
-                    "use --format dsd64|dsd128|dsd256 matching the file, "
+                    "use --format dsd64|dsd128|dsd256|dsd512|dsd1024|dsd2048 matching the file, "
                     "and --channels to match.\n",
                     src->channels, src->rate, channels, rate_hz);
             src->close(src);
@@ -636,7 +690,11 @@ int main(int argc, char **argv)
     }
 
     uint8_t *frame = calloc(1, max_frame);
-    if (!frame) return 1;
+    uint8_t *audio_buf = calloc(1, max_microframe_payload);
+    if (!frame || !audio_buf) {
+        fprintf(stderr, "talker: out of memory allocating frame/audio buffers\n");
+        return 1;
+    }
 
     /* L2 / AVTP have an Ethernet header prefix; IP mode does not. */
     if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
@@ -667,17 +725,29 @@ int main(int argc, char **argv)
         | (uint64_t)STREAM_ID;
     uint8_t avtp_seq8 = 0;
 
+    /* Predicted fragment count for the nominal microframe. K=1 is the
+     * common case; larger values report the split that will be applied
+     * to DSD512+ and high-rate multichannel PCM. AVTP reports "no-frag". */
+    int nominal_K = 1;
+    if (transport != TRANSPORT_AVTP && max_frag_pc > 0) {
+        int nominal_pc = (int)(nominal_spm + 0.5);
+        if (nominal_pc < 1) nominal_pc = 1;
+        nominal_K = (nominal_pc + max_frag_pc - 1) / max_frag_pc;
+    }
+
     if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
         const char *label = (transport == TRANSPORT_AVTP) ? "avtp" : "l2";
         fprintf(stderr,
                 "talker: transport=%s iface=%s ifindex=%d\n"
                 "        src=%02x:%02x:%02x:%02x:%02x:%02x dst=%02x:%02x:%02x:%02x:%02x:%02x\n"
-                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_frame=%zuB feedback=on\n",
+                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_frag_pc=%d frags/microframe=%d max_frame=%zuB feedback=on\n",
                 label, iface, ifindex,
                 src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
                 dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
                 transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : format_s,
-                channels, rate_hz, nominal_spm, max_samples_per_packet, max_frame);
+                channels, rate_hz, nominal_spm,
+                transport == TRANSPORT_AVTP ? 0 : max_frag_pc,
+                nominal_K, max_frame);
     } else {
         char ip_str[INET6_ADDRSTRLEN] = {0};
         if (dest_family == AF_INET) {
@@ -692,13 +762,13 @@ int main(int argc, char **argv)
         fprintf(stderr,
                 "talker: transport=ip dest=%s:%d family=%s %s\n"
                 "        iface=%s ifindex=%d\n"
-                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_spp=%d max_payload=%zuB feedback=on\n",
+                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_frag_pc=%d frags/microframe=%d max_payload=%zuB feedback=on\n",
                 ip_str, udp_port,
                 dest_family == AF_INET ? "v4" : "v6",
                 dest_is_multicast ? "multicast" : "unicast",
                 iface, ifindex,
                 format_s, channels, rate_hz,
-                nominal_spm, max_samples_per_packet,
+                nominal_spm, max_frag_pc, nominal_K,
                 max_frame - sizeof(struct ether_header));
     }
 
@@ -857,73 +927,124 @@ int main(int argc, char **argv)
         }
         if (ticks > 1) late_wakeups++;
 
-        /* 4. Emit `ticks` packets. Each packet's payload_count is the
-         *    integer part of the accumulator; residual carries forward. */
+        /* 4. Emit `ticks` microframes. Each microframe carries `pc`
+         *    bytes-or-samples per channel. In the common case a microframe
+         *    becomes one packet; DSD512+ and high-rate multichannel PCM are
+         *    split into K back-to-back fragments with consecutive sequence
+         *    numbers and last-in-group set only on fragment K-1. AVTP paths
+         *    never fragment (single packet per microframe). */
         for (uint64_t i = 0; i < ticks && !g_stop; i++) {
             sample_accum += samples_per_microframe;
             int pc = (int)sample_accum;
             if (pc < 1) pc = 1;
-            if (pc > max_samples_per_packet) pc = max_samples_per_packet;
+            if (pc > max_samples_per_microframe) pc = max_samples_per_microframe;
             sample_accum -= pc;
 
-            if (src->read(src, payload, (size_t)pc) < 0) {
+            /* Read one microframe of audio into the standalone audio_buf.
+             * The source writes `pc` samples/bytes per channel, interleaved
+             * per AOE wire format (sample-interleaved for PCM, byte-
+             * interleaved for DSD). Slices of this buffer become valid
+             * per-fragment payloads with a simple byte-range split, because
+             * the first N units per channel are always the first
+             * N × channels × bytes_per_sample bytes of the buffer. */
+            if (src->read(src, audio_buf, (size_t)pc) < 0) {
                 g_stop = 1;
                 break;
             }
 
-            const size_t payload_bytes =
-                (size_t)pc * channels * bytes_per_sample;
-            size_t frame_len_total =
-                sizeof(struct ether_header) + proto_hdr_len + payload_bytes;
-
+            /* Fragment count and per-fragment pc distribution. AVTP is
+             * always K=1; AOE uses max_frag_pc computed at startup. */
+            int K;
+            int base, rem;
             if (transport == TRANSPORT_AVTP) {
-                /* AAF carries 24-bit samples big-endian; ALSA gives us LE.
-                 * Swap in place before transmit. */
-                avtp_swap24_inplace(payload,
-                                    (size_t)pc * (size_t)channels);
-                avtp_aaf_hdr_build(avtp_hdr_p,
-                                   avtp_stream_id,
-                                   avtp_seq8++,
-                                   0,                    /* avtp_timestamp (no PTP yet) */
-                                   AAF_FORMAT_INT24,
-                                   avtp_nsr_code,
-                                   (uint16_t)channels,
-                                   24,                   /* bit_depth */
-                                   (uint16_t)payload_bytes);
+                K = 1;
+                base = pc;
+                rem  = 0;
             } else {
-                aoe_hdr_build(aoe_hdr_p, STREAM_ID, seq, 0,
-                              (uint8_t)channels, format_code, (uint8_t)pc,
-                              AOE_FLAG_LAST_IN_GROUP);
+                K = (pc + max_frag_pc - 1) / max_frag_pc;
+                if (K < 1) K = 1;
+                base = pc / K;
+                rem  = pc % K;   /* first `rem` fragments get base+1 */
             }
 
-            /* If Hive has bound us via ACMP CONNECT_TX, override the CLI
-             * --dest-mac on egress. AVDECC is L2-only; the IP path keeps
-             * its static --dest-ip. */
+            /* If AVDECC bound us this tick, steer the destination for all
+             * fragments of this microframe together. Taking the snapshot
+             * once per microframe (not per fragment) keeps a group's
+             * fragments on the same peer even if an unbind races a send. */
+            int steer_avdecc = 0;
+            uint8_t avdecc_mac_snap[6];
             if (transport != TRANSPORT_IP) {
                 pthread_mutex_lock(&g_avdecc_mu);
                 if (g_avdecc_dest_valid) {
-                    struct ether_header *eth = (struct ether_header *)frame;
-                    memcpy(eth->ether_dhost, g_avdecc_dest_mac, 6);
-                    memcpy(data_to_ll.sll_addr, g_avdecc_dest_mac, 6);
+                    memcpy(avdecc_mac_snap, g_avdecc_dest_mac, 6);
+                    steer_avdecc = 1;
                 }
                 pthread_mutex_unlock(&g_avdecc_mu);
+                if (steer_avdecc) {
+                    struct ether_header *eth = (struct ether_header *)frame;
+                    memcpy(eth->ether_dhost, avdecc_mac_snap, 6);
+                    memcpy(data_to_ll.sll_addr, avdecc_mac_snap, 6);
+                }
             }
 
-            ssize_t sent;
-            if (transport == TRANSPORT_IP) {
-                sent = sendto(data_sock, frame + tx_offset, frame_len_total - tx_offset, 0,
-                              (struct sockaddr *)&dest_ss, dest_ss_len);
-            } else {
-                sent = sendto(data_sock, frame, frame_len_total, 0,
-                              (struct sockaddr *)&data_to_ll, sizeof(data_to_ll));
+            int off_units = 0;
+            int abort_microframe = 0;
+            for (int k = 0; k < K && !g_stop; k++) {
+                const int frag_pc = base + (k < rem ? 1 : 0);
+                const size_t frag_payload_bytes =
+                    (size_t)frag_pc * channels * bytes_per_sample;
+                const size_t audio_offset =
+                    (size_t)off_units * channels * bytes_per_sample;
+
+                /* Copy this fragment's audio slice into the frame payload
+                 * area. For AVTP K=1 so this copies the whole microframe. */
+                memcpy(payload, audio_buf + audio_offset, frag_payload_bytes);
+
+                if (transport == TRANSPORT_AVTP) {
+                    /* AAF samples are big-endian on the wire; ALSA is LE.
+                     * Swap in place after the memcpy above. */
+                    avtp_swap24_inplace(payload,
+                                        (size_t)frag_pc * (size_t)channels);
+                    avtp_aaf_hdr_build(avtp_hdr_p,
+                                       avtp_stream_id,
+                                       avtp_seq8++,
+                                       0,                    /* avtp_timestamp (no PTP yet) */
+                                       AAF_FORMAT_INT24,
+                                       avtp_nsr_code,
+                                       (uint16_t)channels,
+                                       24,                   /* bit_depth */
+                                       (uint16_t)frag_payload_bytes);
+                } else {
+                    const uint8_t flags =
+                        (k == K - 1) ? AOE_FLAG_LAST_IN_GROUP : 0;
+                    aoe_hdr_build(aoe_hdr_p, STREAM_ID, seq, 0,
+                                  (uint8_t)channels, format_code,
+                                  (uint8_t)frag_pc, flags);
+                }
+
+                const size_t frame_len_total =
+                    sizeof(struct ether_header) + proto_hdr_len + frag_payload_bytes;
+
+                ssize_t sent;
+                if (transport == TRANSPORT_IP) {
+                    sent = sendto(data_sock, frame + tx_offset,
+                                  frame_len_total - tx_offset, 0,
+                                  (struct sockaddr *)&dest_ss, dest_ss_len);
+                } else {
+                    sent = sendto(data_sock, frame, frame_len_total, 0,
+                                  (struct sockaddr *)&data_to_ll,
+                                  sizeof(data_to_ll));
+                }
+                if (sent < 0) {
+                    if (errno == EINTR) { abort_microframe = 1; break; }
+                    perror("sendto");
+                    g_stop = 1;
+                    break;
+                }
+                seq++;
+                off_units += frag_pc;
             }
-            if (sent < 0) {
-                if (errno == EINTR) break;
-                perror("sendto");
-                g_stop = 1;
-                break;
-            }
-            seq++;
+            if (abort_microframe) break;
         }
     }
 
@@ -937,6 +1058,7 @@ int main(int argc, char **argv)
     if (fb_sock != data_sock) close(fb_sock);
     close(data_sock);
     free(frame);
+    free(audio_buf);
     aoether_avdecc_close(avdecc);
     return 0;
 }


### PR DESCRIPTION
## Summary

Lifts the two ceilings that have been blocking DSD512+ and very-high-rate multichannel PCM:

- `payload_count` is `u8`, so DSD formats above DSD256 (≥ 353 bytes/channel/microframe) can't fit in a single packet.
- A microframe that exceeds the 1500 B MTU has to be split regardless.

Per-microframe fragmentation handles both. A microframe becomes K back-to-back packets with consecutive sequence numbers, shared `presentation_time` / `stream_id` / `format` / `channel_count`, and `flags.last-in-group=1` only on the final fragment. K=1 in the common case, 2 for DSD512 stereo, 3 for DSD1024 stereo, 6 for DSD2048 stereo.

Resolves the pre-existing contradiction in `wire-format.md` where the header table called sequence monotonic per stream and the "Cadence" section said fragments share a sequence — the former is the new rule, the latter was a design placeholder that was never implemented. Design-discussion record is in #12.

## Highlights

- **No new header fields.** The `last-in-group` flag was already reserved for exactly this; sequence stays `u32` monotonic per packet.
- **No receiver-side reassembly state.** Each fragment is a valid standalone AoE data frame. The existing per-packet ALSA-write path produces the correct continuous audio because fragments arrive in order and per-fragment `payload_count`s sum to the microframe's total `pc`. Existing sequence-gap loss detection continues to work — a lost middle fragment produces a delta-of-2 gap and a short write at ALSA, equivalent to a tiny underrun.
- **AVTP AAF is deliberately out of scope.** Splitting an AAF stream across multiple 1722 frames per microframe breaks interop with strict Milan listeners, so `--transport avtp` keeps the single-packet-per-microframe constraint and still rejects MTU-overflowing configs at startup. Fragmentation applies only to Mode 1 (L2) and Mode 3 (IP/UDP).
- **DSD1024 / DSD2048 exposed as first-class `--format` options**, not gated behind "pending hardware validation". `snd_usb_audio` quirk support for these rates is already mainline; any DAC Linux recognizes at those rates now works end-to-end.

## Files

- `docs/wire-format.md` — new §"Cadence and fragmentation" with the full rule set and worked examples for DSD512/1024/2048. Sequence-number field description rewritten. Flags-byte last-in-group rewrite. Frame-size table updated.
- `docs/design.md` — M8 section restructured into `[shipped]` / `[open]` / `[hardware-blocked]` buckets; packet splitting and DSD512/1024/2048 marked shipped.
- `docs/recipe-dsd.md` — DSD512/1024/2048 now listed as supported.
- `talker/src/talker.c` — DSD512/1024/2048 in format table; new `max_frag_pc` computation at startup; emit loop rewritten to read the microframe once into `audio_buf`, walk K fragments, memcpy each slice into `frame.payload`, build per-fragment headers, send. AVDECC dest-MAC snapshotted per-microframe so a group's fragments stay on one peer.
- `receiver/src/receiver.c` — DSD512/1024/2048 in format table and help text; no data-path change (each fragment is a standalone AoE frame already handled by the existing ALSA-write path).
- `talker/src/audio_source.h`, `talker/src/audio_source_dsf.c` — DSF reader accepts 22579200 / 45158400 / 90316800 Hz sampling rates.

## Test plan

- [ ] `cd talker && make` and `cd receiver && make` on a Linux box with `libasound2-dev` build cleanly.
- [ ] DSD64/128/256 regression: `--format dsd64` still emits single packets with `last-in-group=1`, payload unchanged. Banner shows `frags/microframe=1`.
- [ ] DSD512 stereo: banner shows `frags/microframe=2`; tcpdump shows alternating 388-B and 386-B frames; DAC front panel reports DSD512; no xruns over 5 min.
- [ ] DSD1024 stereo: `frags/microframe=3`; DAC reports DSD1024 (quirk permitting); no xruns over 5 min.
- [ ] DSD2048 stereo on a DSD2048-capable DAC: `frags/microframe=6`; no xruns over 5 min.
- [ ] Packet loss simulation (`tc netem loss 0.1%`): receiver `lost` counter reflects fragment-level losses; ALSA keeps playing; no persistent xrun cascade.
- [ ] AVTP regression: `--transport avtp --format pcm` still emits one packet per microframe with the existing MTU-reject path for overflowing configs.
- [ ] DSF file at DSD512 plays end-to-end via `--source dsf --file X.dsf --format dsd512`.

## Issue

Closes #12 on merge.
