### PR TITLE
Add RTP/AES67 transport (M9 Phase A)

### DIFF
--- a/common/rtp.c
+++ b/common/rtp.c
@@ -1,0 +1,62 @@
+#include "rtp.h"
+
+#include <arpa/inet.h>
+#include <stddef.h>
+#include <stdint.h>
+
+void rtp_hdr_build(struct rtp_hdr *h,
+                   uint8_t  payload_type,
+                   uint16_t sequence,
+                   uint32_t timestamp,
+                   uint32_t ssrc)
+{
+    /* V=2 (bits 7-6), P=0, X=0, CC=0. M=0 (bits 7-1 are PT). */
+    h->vpxcc     = (uint8_t)(RTP_VERSION << 6);
+    h->mpt       = (uint8_t)(payload_type & 0x7F);
+    h->sequence  = htons(sequence);
+    h->timestamp = htonl(timestamp);
+    h->ssrc      = htonl(ssrc);
+}
+
+int rtp_hdr_parse(const struct rtp_hdr *h,
+                  uint8_t  *out_pt,
+                  uint16_t *out_sequence,
+                  uint32_t *out_timestamp,
+                  uint32_t *out_ssrc)
+{
+    const uint8_t version = (uint8_t)(h->vpxcc >> 6);
+    const uint8_t padding = (uint8_t)((h->vpxcc >> 5) & 1);
+    const uint8_t extflag = (uint8_t)((h->vpxcc >> 4) & 1);
+    const uint8_t cc      = (uint8_t)(h->vpxcc & 0x0F);
+    if (version != RTP_VERSION) return -1;
+    /* AOEther only accepts the plain-vanilla RTP header today — no CSRC
+     * list, no header extension, no padding. AES67 talkers don't use
+     * these in practice. */
+    if (cc != 0 || extflag != 0 || padding != 0) return -1;
+    if (out_pt)        *out_pt        = (uint8_t)(h->mpt & 0x7F);
+    if (out_sequence)  *out_sequence  = ntohs(h->sequence);
+    if (out_timestamp) *out_timestamp = ntohl(h->timestamp);
+    if (out_ssrc)      *out_ssrc      = ntohl(h->ssrc);
+    return 0;
+}
+
+void rtp_swap24_inplace(uint8_t *buf, size_t nsamples)
+{
+    /* L24 samples are 3 bytes each; swap byte[0] and byte[2] per sample. */
+    for (size_t i = 0; i < nsamples; i++) {
+        uint8_t *s = buf + i * 3u;
+        const uint8_t tmp = s[0];
+        s[0] = s[2];
+        s[2] = tmp;
+    }
+}
+
+void rtp_swap16_inplace(uint8_t *buf, size_t nsamples)
+{
+    for (size_t i = 0; i < nsamples; i++) {
+        uint8_t *s = buf + i * 2u;
+        const uint8_t tmp = s[0];
+        s[0] = s[1];
+        s[1] = tmp;
+    }
+}

--- a/common/rtp.h
+++ b/common/rtp.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* AOEther Mode 4 (M9) — RTP/AES67 wire encoding.
+ *
+ * Mode 4 carries PCM audio as RTP over UDP for interop with the Ravenna /
+ * AES67 ecosystem (any AES67 device: aes67-linux-daemon, Merging Anubis,
+ * Neumann MT 48, Dante-with-AES67-mode, Ravenna-native gear, etc.). The
+ * header is standard RTP (RFC 3550) with an L24 or L16 payload per RFC
+ * 3190 / AES67 §7.
+ *
+ * The RTP header below is plain IETF — there's no AOEther-specific
+ * framing on top. The stream is identified by the RTP SSRC and the UDP
+ * (destination address, port) tuple; SDP / SAP (M9 Phase B) carry the
+ * session description out-of-band.
+ *
+ * Bytes-on-wire (big-endian throughout, unlike our LE AoE path):
+ *
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |V=2|P|X|  CC   |M|     PT      |       sequence number         |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |                           timestamp                           |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |            synchronization source (SSRC) identifier           |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * AOEther emits: V=2, P=0, X=0, CC=0, M=0. Payload type (PT) is dynamic
+ * per AES67 — controllers normally negotiate it via SDP; the baseline
+ * default 96 is used below until SDP lands. The RTP timestamp is the
+ * stream's media clock sample count (advancing by `samples_per_packet`
+ * per packet at the stream's sample rate).
+ *
+ * Payload (after the 12-byte header):
+ *   - L24: signed 24-bit PCM, big-endian on the wire, channel-interleaved.
+ *     `channels × samples_per_packet × 3` bytes.
+ *   - L16: signed 16-bit PCM, big-endian on the wire, channel-interleaved.
+ *     `channels × samples_per_packet × 2` bytes.
+ *
+ * AOEther's ALSA source/sink is little-endian (`S24_3LE` / `S16_LE`), so
+ * the talker byte-swaps on egress and the receiver byte-swaps on ingress.
+ * This mirrors the AAF (Mode 2) data-path endianness flip.
+ *
+ * Cadence (PTIME):
+ *   - 1 ms is the AES67 standard default (48 samples/packet at 48 kHz).
+ *   - 125 µs is the AES67 "low-latency" profile (6 samples/packet at
+ *     48 kHz). Matches AOEther's existing 8000 pps microframe cadence.
+ *   - Others (250 µs, 333 µs) exist in the spec but AOEther only supports
+ *     the two above for M9 Phase A.
+ *
+ * Mode C clock-discipline feedback is NOT emitted in Mode 4. AES67
+ * devices expect PTPv2 (default profile) as the time source, not our
+ * UAC2-shape feedback. Running AOEther's Mode 4 path against a strict
+ * AES67 endpoint requires a PTPv2 grandmaster on the network. See
+ * docs/recipe-aes67.md for deployment notes. */
+
+#define RTP_HDR_LEN             12
+#define RTP_VERSION             2
+
+/* Default dynamic payload type until SDP-negotiated values arrive. */
+#define RTP_DEFAULT_PT_L24      96
+#define RTP_DEFAULT_PT_L16      97
+
+/* AES67 default destination port for RTP media. */
+#define RTP_DEFAULT_PORT        5004
+
+/* Supported PTIME values for M9 Phase A, in microseconds. */
+#define RTP_PTIME_US_1MS        1000
+#define RTP_PTIME_US_125US      125
+
+struct rtp_hdr {
+    uint8_t  vpxcc;         /* V=2, P, X, CC */
+    uint8_t  mpt;           /* M, PT (payload type) */
+    uint16_t sequence;      /* big-endian on wire */
+    uint32_t timestamp;     /* big-endian on wire; media-clock sample count */
+    uint32_t ssrc;          /* big-endian on wire */
+} __attribute__((packed));
+
+_Static_assert(sizeof(struct rtp_hdr) == RTP_HDR_LEN,
+               "RTP header must be exactly 12 bytes");
+
+/* Build an RTP header into `h`. V=2, P=0, X=0, CC=0, M=0 — all values
+ * controllers normally expect from an AES67 talker. */
+void rtp_hdr_build(struct rtp_hdr *h,
+                   uint8_t  payload_type,
+                   uint16_t sequence,
+                   uint32_t timestamp,
+                   uint32_t ssrc);
+
+/* Parse + validate an RTP header. Returns 0 on success and fills the
+ * out-parameters; returns -1 if the header is malformed (bad version,
+ * unexpected extensions, too-small input).
+ *
+ * Only V=2 with CC=0 and X=0 is accepted — CSRC lists and header
+ * extensions are rare on AES67 audio streams and AOEther doesn't need
+ * them today. Extending to accept CC>0 or X=1 means parsing past the
+ * fixed header to find the payload start. */
+int rtp_hdr_parse(const struct rtp_hdr *h,
+                  uint8_t  *out_pt,
+                  uint16_t *out_sequence,
+                  uint32_t *out_timestamp,
+                  uint32_t *out_ssrc);
+
+/* Byte-swap 24-bit samples in-place between BE (wire) and LE (ALSA).
+ * `nsamples` is total samples (channels × frames). The operation is
+ * its own inverse — call it on the same buffer to swap both ways. */
+void rtp_swap24_inplace(uint8_t *buf, size_t nsamples);
+
+/* Byte-swap 16-bit samples in-place. Same inverse property as above. */
+void rtp_swap16_inplace(uint8_t *buf, size_t nsamples);

--- a/docs/design.md
+++ b/docs/design.md
@@ -505,21 +505,27 @@ Ships in pieces as sub-features land rather than as one atomic milestone. Items 
 
 **Goal:** First-class interop with the Ravenna / AES67 ecosystem via Mode 4 (RTP over UDP). Opens the project to a much larger adjacent market: any AES67 device (Merging Anubis, Neumann MT 48, any Ravenna-native gear, any Dante-with-AES67-mode device, any `aes67-linux-daemon` deployment) becomes a valid talker or listener alongside AOEther-native endpoints.
 
-**Deliverables:**
-- **RTP/AES67 encapsulation** for PCM streams: L16 and L24 payload types, 1 ms packet time (PTIME=1 by default, 125 µs optional for low-latency), 48 kHz baseline with optional higher rates.
-- **SDP session description** per AES67 conventions, carrying stream format, packet time, channel count, source, destination, and PTP domain info.
-- **SAP (Session Announcement Protocol)** for stream discovery, interoperable with AES67 discovery implementations.
-- **PTPv2 default profile** support (separate from gPTP which is 802.1AS) for sync with AES67 infrastructure. Linuxptp's `ptp4l` supports both profiles; configuration is per-deployment.
-- **Interop test plan:** confirmed playback with at least `aes67-linux-daemon` (open-source reference), and aspirationally one commercial device per ecosystem (a Dante-with-AES67 device, a Ravenna-native device, a Merging or Neumann endpoint).
-- **Documented constraints:** AES67 is PCM only, so DSD streams remain on Mode 3 (IP/UDP with AoE header). AES67 channel counts typically cap at 8 per stream; higher counts split across streams.
-- **User-facing config** for Mode 4 is kept simple: "I want to send this stream as AES67" / "I want to receive AES67 streams" as first-class options alongside the AOEther-native modes.
+Ships in phases:
+
+**Phase A — [shipped] RTP/AES67 wire encoding.** `--transport rtp` on both talker and receiver, 12-byte RTP header (RFC 3550) followed by L24 big-endian PCM payload (RFC 3190 / AES67 §7). PTIME is 1 ms by default (AES67 standard) and 125 µs optionally (the AES67 low-latency profile, matching AOEther's native microframe cadence). Destination typically IPv4 multicast `239.X.X.X` on UDP port 5004. Mode C feedback is disabled under RTP — AES67 devices expect PTPv2 for clocking and will discard our 0x88B6 frames. Fragmentation is disabled (strict AES67 listeners won't reassemble); configs that exceed MTU are rejected at startup. Only the default dynamic payload type (96 for L24) is emitted/accepted today; SDP-negotiated PTs arrive in Phase B.
+
+**Phase B — [open] SDP / SAP discovery.** SDP session description per AES67 conventions; SAP (RFC 2974) announcement on `239.255.255.255:9875`. User-facing: `--announce-sap` on the talker, passive listen on the receiver, or static SDP files for hostile networks. Enables auto-discovery of AES67 streams from Merging ANEMAN, Dante Controller, etc.
+
+**Phase C — [open] PTPv2 default-profile integration.** PTPv2 default profile is separate from gPTP (802.1AS) that Milan uses. `ptp4l` supports both. AOEther needs: a documented `ptp4l` config recipe, RTP timestamp derivation from `CLOCK_TAI`, and `tv=1`-equivalent indication that the RTP timestamp is PTP-disciplined. Landing this requires M3 Phase B (hardware PTP) to have been validated first.
+
+**Phase D — [hardware-blocked] Interop validation.** Confirmed playback with `aes67-linux-daemon` (open-source reference), Merging ANEMAN / Anubis, a Dante-with-AES67-mode device, and a Neumann or similar Ravenna endpoint.
+
+**Documented constraints:**
+- AES67 is PCM only, so DSD streams remain on Modes 1 / 3 (with AoE header). The talker / receiver reject `--transport rtp --format dsd*` at startup.
+- AES67 channel counts typically cap at 8 per stream; higher counts split across multiple streams at the SDP level (Phase B).
+- L16 payload is wire-format-ready (`rtp_swap16_inplace` exists) but not yet plumbed as a `--format` option — s24 is AOEther's PCM lock.
 
 **Key risks:**
 - AES67 has enough ambiguity in practice that interop edge cases are expected. Approach: start with `aes67-linux-daemon` as a known-good reference, then expand to commercial gear with iteration.
 - SAP multicast is sometimes blocked by consumer routers; document workarounds (static SDP files, manual stream addition).
 - PTP domain coexistence with gPTP deployments (Milan uses domain 0 typically; AES67 setups often use other domains). Ensure AOEther can participate in both simultaneously if needed.
 
-**Time estimate:** 4–6 weekends.
+**Time estimate:** 4–6 weekends total; Phase A is the first weekend's worth.
 
 ### Future work — Topology A (gadget mode), redundancy
 

--- a/docs/recipe-aes67.md
+++ b/docs/recipe-aes67.md
@@ -1,0 +1,92 @@
+## Recipe: AOEther as an AES67 talker / listener (M9 Phase A)
+
+Mode 4 carries audio as plain RTP with an L24 payload, matching the AES67 / Ravenna data plane. This lets AOEther endpoints interoperate with aes67-linux-daemon, Merging Anubis, Neumann MT 48, Dante-with-AES67, and other AES67-compliant devices on the same network.
+
+This recipe covers **Phase A only** — RTP wire encoding is live; SDP session description, SAP discovery, and PTPv2 timestamp discipline are tracked separately (see `design.md` M9 phases B / C).
+
+For the byte layout see [`wire-format.md`](wire-format.md) §"Mode 4 (RTP / AES67)".
+
+## Talker → AES67 listener
+
+Emit a stereo 48 kHz L24 stream at AES67's default PTIME (1 ms):
+
+```sh
+sudo ./build/talker --iface eno1 \
+                    --transport rtp \
+                    --dest-ip 239.69.1.10 \
+                    --port 5004 \
+                    --source testtone \
+                    --channels 2 --rate 48000
+```
+
+Switch to the AES67 low-latency profile (125 µs PTIME, matching AOEther's native cadence):
+
+```sh
+sudo ./build/talker --iface eno1 --transport rtp \
+                    --dest-ip 239.69.1.10 --ptime 125 \
+                    --source testtone --channels 2 --rate 48000
+```
+
+What the talker does in Mode 4:
+
+- Opens a UDP socket; joins no group (multicast-send doesn't require membership).
+- DSCP EF marking on egress, same as Mode 3.
+- Builds an RTP header per packet: `V=2`, `P=0`, `X=0`, `CC=0`, `M=0`, `PT=96` (dynamic default for L24), monotonic 16-bit sequence, timestamp advancing by `payload_count` samples per packet.
+- Byte-swaps each 24-bit sample from ALSA's little-endian to the wire's big-endian.
+- Does not emit Mode C feedback frames — AES67 devices expect PTPv2 for clocking and would drop our 0x88B6 frames anyway.
+- Does not start an AVDECC entity even if `--avdecc` is passed — AVDECC is a Milan concept; AES67 uses SAP / SDP.
+
+## AOEther receiver ← AES67 talker
+
+The same endpoint can also listen to an AES67 stream from any compliant talker:
+
+```sh
+sudo ./build/receiver --iface eth0 --dac hw:CARD=D90,DEV=0 \
+                      --transport rtp \
+                      --group 239.69.1.10 \
+                      --port 5004 \
+                      --channels 2 --rate 48000
+```
+
+`--group` joins the IGMP multicast group; omit it for unicast deployments where the sender targets the receiver's own IP. The receiver parses RTP, byte-swaps L24 samples to little-endian, and writes to ALSA via the same path used by Modes 1/3. Mode C feedback is not emitted (see above).
+
+## Interop test — aes67-linux-daemon
+
+The open-source reference is [aes67-linux-daemon](https://github.com/bondagit/aes67-linux-daemon). Install it on a second Linux box on the same segment, create a sink matching AOEther's stream (239.69.1.10:5004, 48 kHz, stereo, L24, PTIME=1 ms, PT=96), and it should show up with live packets flowing. Clocking drift will be visible — see "Clock considerations" below.
+
+Dante-with-AES67-mode, Merging, and Neumann devices expect SDP / SAP for stream description; they won't auto-discover a raw RTP stream from this Phase A talker. Until Phase B ships SAP, feed them a static SDP file manually.
+
+An AES67-compliant static SDP for the talker example above looks like:
+
+```
+v=0
+o=- 0 0 IN IP4 192.168.1.100
+s=AOEther test stream
+c=IN IP4 239.69.1.10/32
+t=0 0
+m=audio 5004 RTP/AVP 96
+a=rtpmap:96 L24/48000/2
+a=ptime:1
+a=recvonly
+a=source-filter: incl IN IP4 * 192.168.1.100
+```
+
+Substitute your talker's host IP for `192.168.1.100`. For the low-latency profile change `a=ptime:1` to `a=ptime:0.125`. Most AES67 devices will accept the stream once pointed at this SDP.
+
+## Clock considerations
+
+**There is no PTP in this phase.** The talker emits on a local monotonic timer; the RTP timestamp advances by `payload_count` samples per packet, measured from a local start time. AES67 listeners typically expect the timestamp to be PTP-disciplined — they will play the stream, but clock drift relative to the listener's PTP grandmaster will cause buffer-level drift over long sessions.
+
+For short sessions (a few minutes), drift is small and usually not audible. For continuous playback, PTPv2 integration is required — tracked as M9 Phase C.
+
+If the listener exposes a "free-run" or "no-lock" mode, enable it when testing against this Phase A talker.
+
+## Known limitations (Phase A)
+
+- No SDP, no SAP. Stream metadata must be conveyed out-of-band.
+- No PTPv2 timestamp locking.
+- No payload-type negotiation — talker emits PT=96 unconditionally, receiver accepts any PT.
+- L16 encoding path exists in the common module but isn't exposed yet.
+- 44.1 kHz / 88.2 kHz / 176.4 kHz work at the wire level but AES67 deployments overwhelmingly use 48 kHz / 96 kHz.
+- `--transport rtp --format dsd*` is rejected; AES67 is PCM-only. DSD streams remain on Modes 1 / 3.
+- Multichannel beyond stereo works but AES67 conventions cap per-stream channel count at 8. Higher counts split across streams at the SDP level (Phase B).

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -310,6 +310,51 @@ AOEther's Mode C clock-discipline FEEDBACK frames continue to flow on EtherType 
 
 Milan typically uses multicast destination MACs in the AVTP-reserved range `91:E0:F0:00:00:00/40`. AOEther's talker accepts any unicast or multicast MAC via `--dest-mac`; it does not register addresses with a switch via MSRP (that's Avnu/Milan controller territory and arrives no earlier than M7 alongside AVDECC).
 
+## Mode 4 (RTP / AES67)
+
+When `--transport rtp` is selected (M9 Phase A), PCM streams are emitted as plain RFC 3550 RTP over UDP with an RFC 3190 L24 payload, matching the AES67 data-plane profile. There is no AOEther-specific framing on top — a strict AES67 listener sees a standard RTP audio stream.
+
+### RTP header (12 bytes)
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|V=2|P|X|  CC   |M|     PT      |       sequence number         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           timestamp                           |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             SSRC                              |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+AOEther's emitter sets V=2, P=0, X=0, CC=0, M=0, PT=96 (dynamic, default). SSRC is a stable 32-bit identifier derived from the talker's MAC XOR'd with the stream ID — survives restarts at the same iface. RTP timestamp advances by `payload_count` samples per packet at the stream's sample rate.
+
+### Payload
+
+L24: signed 24-bit PCM, big-endian on the wire, channel-interleaved. Total payload bytes = `channels × payload_count × 3`. The talker byte-swaps on egress from ALSA's `S24_3LE`; the receiver byte-swaps on ingress. This is the same direction and mechanism as Mode 2 AAF.
+
+L16 is wire-format-supported (helpers provided in `common/rtp.c`) but not yet exposed as a `--format` option — AOEther's PCM lock is s24 today.
+
+### Packet cadence (PTIME)
+
+| PTIME | Packets/second | AES67 profile | AOEther `--ptime` |
+|---|---|---|---|
+| 1 ms | 1000 | default | 1000 (default for Mode 4) |
+| 125 µs | 8000 | low-latency | 125 |
+
+Mode 4 does **not** use fragmentation. Configs whose per-packet payload would exceed 1500-byte MTU are rejected at talker startup. The fragmentation path is AoE-only (Modes 1/3).
+
+### Addressing
+
+AES67 typically uses IPv4 multicast in `239.X.X.X` on UDP port 5004. AOEther accepts any unicast or multicast IPv4/IPv6 destination via `--dest-ip`. Receivers optionally join a group via `--group`; for unicast deployments `--group` is omitted and receivers bind to the UDP port.
+
+### What is not in Mode 4 today
+
+- **SDP / SAP** — M9 Phase B. Without SDP, the talker and receiver must agree on format / channels / rate / destination out of band. No dynamic payload-type negotiation.
+- **PTPv2 timestamp discipline** — M9 Phase C. The RTP timestamp advances from a local monotonic clock; it is not PTP-locked. Strict AES67 listeners may tolerate this or may not, depending on their sync policy.
+- **Mode C clock feedback** — disabled entirely under `--transport rtp`. AES67 expects PTP, not UAC2-style feedback. Receivers do not emit 0x88B6 frames when running in RTP mode.
+
 ## Control frames
 
 Control frames carry out-of-band signaling between endpoints. They share the Ethernet wire with data frames but use a distinct EtherType (`0x88B6`) and a distinct header magic byte (`0xA1` vs. `0xA0`), so the two classes are trivially separable by any receiver. Implementations that do not understand a given control frame type MUST discard it without affecting the audio path.

--- a/receiver/Makefile
+++ b/receiver/Makefile
@@ -9,6 +9,7 @@ SRCS      := \
     src/receiver.c \
     ../common/packet.c \
     ../common/avtp.c \
+    ../common/rtp.c \
     ../common/mdns.c \
     ../common/avdecc.c
 
@@ -41,7 +42,7 @@ endif
 .PHONY: all clean
 all: $(BUILD)/receiver
 
-$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h ../common/mdns.h ../common/avdecc.h | $(BUILD)
+$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h ../common/rtp.h ../common/mdns.h ../common/avdecc.h | $(BUILD)
 	$(LINK) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -2,6 +2,7 @@
 #include "avtp.h"
 #include "mdns.h"
 #include "packet.h"
+#include "rtp.h"
 
 #include <pthread.h>
 
@@ -57,6 +58,7 @@ enum transport_mode {
     TRANSPORT_L2 = 0,
     TRANSPORT_IP = 1,
     TRANSPORT_AVTP = 2,
+    TRANSPORT_RTP = 3,   /* RTP/AES67 (Mode 4, M9 Phase A) */
 };
 
 static int rate_supported(int hz)
@@ -174,10 +176,11 @@ static void usage(const char *prog)
 {
     fprintf(stderr,
         "usage: %s --iface IF --dac hw:CARD=NAME,DEV=0 [options]\n"
-        "  --transport l2|ip|avtp  transport mode, default l2\n"
-        "                       (avtp = IEEE 1722 AAF, EtherType 0x22F0, Milan interop)\n"
-        "  --port N             UDP port (IP mode, default %d)\n"
-        "  --group IP           multicast group to join (IP mode, optional;\n"
+        "  --transport l2|ip|avtp|rtp   transport mode, default l2\n"
+        "                       (avtp = IEEE 1722 AAF, Milan interop;\n"
+        "                        rtp  = RTP/AES67 per M9 Phase A)\n"
+        "  --port N             UDP port (ip mode default %d; rtp default 5004)\n"
+        "  --group IP           multicast group to join (ip/rtp modes, optional;\n"
         "                       IPv4 in 224.0.0.0/4 or IPv6 in ff00::/8)\n"
         "  --format FMT         pcm | dsd64 | dsd128 | dsd256\n"
         "                       | dsd512 | dsd1024 | dsd2048\n"
@@ -271,7 +274,8 @@ int main(int argc, char **argv)
             if      (strcmp(optarg, "l2") == 0)   transport = TRANSPORT_L2;
             else if (strcmp(optarg, "ip") == 0)   transport = TRANSPORT_IP;
             else if (strcmp(optarg, "avtp") == 0) transport = TRANSPORT_AVTP;
-            else { fprintf(stderr, "receiver: --transport must be l2, ip, or avtp\n"); return 2; }
+            else if (strcmp(optarg, "rtp") == 0)  transport = TRANSPORT_RTP;
+            else { fprintf(stderr, "receiver: --transport must be l2, ip, avtp, or rtp\n"); return 2; }
             break;
         case 'P': udp_port = atoi(optarg); break;
         case 'G': group_s = optarg; break;
@@ -296,9 +300,13 @@ int main(int argc, char **argv)
         fprintf(stderr, "receiver: --port out of range\n");
         return 2;
     }
-    if (transport != TRANSPORT_IP && group_s) {
-        fprintf(stderr, "receiver: --group only makes sense with --transport ip\n");
+    if (transport != TRANSPORT_IP && transport != TRANSPORT_RTP && group_s) {
+        fprintf(stderr, "receiver: --group only makes sense with --transport ip or rtp\n");
         return 2;
+    }
+    if (transport == TRANSPORT_RTP && udp_port == DEFAULT_UDP_PORT) {
+        /* AES67 registered RTP port is 5004. */
+        udp_port = RTP_DEFAULT_PORT;
     }
 
     if (channels < 1 || channels > 64) {
@@ -319,6 +327,10 @@ int main(int argc, char **argv)
     }
     if (transport == TRANSPORT_AVTP && fmt.is_dsd) {
         fprintf(stderr, "receiver: AVTP AAF does not carry DSD; use --transport l2 or ip\n");
+        return 2;
+    }
+    if (transport == TRANSPORT_RTP && fmt.is_dsd) {
+        fprintf(stderr, "receiver: AES67 RTP is PCM-only; use --transport l2 or ip with --format dsd*\n");
         return 2;
     }
 
@@ -503,7 +515,9 @@ int main(int argc, char **argv)
     signal(SIGINT, on_signal);
     signal(SIGTERM, on_signal);
 
-    if (transport != TRANSPORT_IP) {
+    const int feedback_effective =
+        feedback_enabled && transport != TRANSPORT_RTP;
+    if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
         fprintf(stderr,
                 "receiver: transport=%s iface=%s dac=%s fmt=%s alsa=%s ch=%d rate=%d alsa_rate=%u latency_us=%d feedback=%s\n",
                 transport == TRANSPORT_AVTP ? "avtp" : "l2",
@@ -511,19 +525,24 @@ int main(int argc, char **argv)
                 transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : fmt.name,
                 av.name,
                 channels, rate_hz, alsa_rate, latency_us,
-                feedback_enabled ? "on" : "off");
+                feedback_effective ? "on" : "off");
     } else {
+        const char *label = (transport == TRANSPORT_RTP) ? "rtp" : "ip";
+        const char *wire_fmt =
+            (transport == TRANSPORT_RTP) ? "L24(BE)" : fmt.name;
         fprintf(stderr,
-                "receiver: transport=ip family=%s %s port=%d%s%s\n"
-                "          iface=%s dac=%s fmt=%s alsa=%s ch=%d rate=%d alsa_rate=%u latency_us=%d feedback=%s\n",
+                "receiver: transport=%s family=%s %s port=%d%s%s\n"
+                "          iface=%s dac=%s fmt=%s alsa=%s ch=%d rate=%d alsa_rate=%u latency_us=%d feedback=%s%s\n",
+                label,
                 group_family == AF_INET6 ? "v6" : "v4",
                 use_multicast ? "multicast" : "unicast",
                 udp_port,
                 group_s ? " group=" : "",
                 group_s ? group_s : "",
-                iface, dac, fmt.name, av.name,
+                iface, dac, wire_fmt, av.name,
                 channels, rate_hz, alsa_rate, latency_us,
-                feedback_enabled ? "on" : "off");
+                feedback_effective ? "on" : "off",
+                transport == TRANSPORT_RTP ? " (AES67: relies on PTPv2)" : "");
     }
 
     /* mDNS-SD: announce this receiver and its DAC capabilities so talkers
@@ -574,6 +593,12 @@ int main(int argc, char **argv)
      * AOEther listeners through this entity and use ACMP CONNECT_RX to
      * bind a peer talker at runtime. Currently scaffolding only — the
      * descriptor tree and ACMP handler are filled in by step 2. */
+    if (avdecc_enabled && transport == TRANSPORT_RTP) {
+        fprintf(stderr,
+                "receiver: --avdecc has no effect under --transport rtp "
+                "(AES67 uses SAP/SDP for discovery; AVDECC is Milan-only)\n");
+        avdecc_enabled = 0;
+    }
     struct aoether_avdecc *avdecc = NULL;
     if (avdecc_enabled) {
         struct aoether_avdecc_config cfg = {
@@ -656,7 +681,7 @@ int main(int argc, char **argv)
             struct sockaddr_storage src_addr;
             socklen_t src_addrlen = sizeof(src_addr);
             ssize_t n;
-            if (transport == TRANSPORT_IP) {
+            if (transport == TRANSPORT_IP || transport == TRANSPORT_RTP) {
                 n = recvfrom(data_sock, buf, sizeof(buf), 0,
                              (struct sockaddr *)&src_addr, &src_addrlen);
             } else {
@@ -671,13 +696,44 @@ int main(int argc, char **argv)
             /* Parse the protocol header into a uniform (frames, payload_ptr,
              * sequence) tuple, then fall through to the common ALSA-write
              * and talker-learning path. */
-            size_t hdr_off = (transport == TRANSPORT_IP) ? 0 : sizeof(struct ether_header);
+            size_t hdr_off = (transport == TRANSPORT_IP || transport == TRANSPORT_RTP)
+                                 ? 0 : sizeof(struct ether_header);
             size_t frames = 0;
             size_t payload_bytes = 0;
             uint8_t *payload_p = NULL;
             uint32_t seq = 0;
 
-            if (transport == TRANSPORT_AVTP) {
+            if (transport == TRANSPORT_RTP) {
+                /* RTP/AES67 path: 12-byte RTP header then L24 big-endian
+                 * PCM. No AoE header, no magic byte — the receiver decides
+                 * this is RTP from --transport rtp. Format / channel
+                 * validation comes from SDP in a future milestone;
+                 * for M9 Phase A we trust --rate / --channels / L24. */
+                if ((size_t)n < hdr_off + RTP_HDR_LEN) { dropped++; goto check_feedback; }
+                const struct rtp_hdr *rh =
+                    (const struct rtp_hdr *)(buf + hdr_off);
+                uint8_t  rpt;
+                uint16_t rseq;
+                uint32_t rts, rssrc;
+                if (rtp_hdr_parse(rh, &rpt, &rseq, &rts, &rssrc) < 0) {
+                    dropped++; goto check_feedback;
+                }
+                (void)rts; (void)rssrc;
+                payload_bytes = (size_t)n - hdr_off - RTP_HDR_LEN;
+                size_t per_sample = (size_t)channels * bytes_per_sample;
+                if (per_sample == 0 || payload_bytes == 0 ||
+                    payload_bytes % per_sample != 0) {
+                    dropped++; goto check_feedback;
+                }
+                frames = payload_bytes / per_sample;
+                payload_p = buf + hdr_off + RTP_HDR_LEN;
+                /* L24 samples are big-endian; swap to ALSA LE in place. */
+                rtp_swap24_inplace(payload_p, frames * (size_t)channels);
+                /* RTP sequence is 16-bit; widen against last using the
+                 * AVTP-style 8-bit handling doesn't apply. Treat it as a
+                 * 32-bit value; the delta compare below handles wrap. */
+                seq = (uint32_t)rseq;
+            } else if (transport == TRANSPORT_AVTP) {
                 if ((size_t)n < hdr_off + AVTP_HDR_LEN) { dropped++; goto check_feedback; }
                 const struct avtp_aaf_hdr *ah =
                     (const struct avtp_aaf_hdr *)(buf + hdr_off);
@@ -728,12 +784,14 @@ int main(int argc, char **argv)
             }
 
             if (have_seq) {
-                /* AVTP wraps every 256 packets; AOE every 2^32. Both work
-                 * with a signed-difference compare against the appropriate
-                 * width — for AVTP we treat seq as 8-bit. */
+                /* AVTP wraps every 256 packets, RTP every 65536, AOE every
+                 * 2^32. Use a width-appropriate signed-difference compare. */
                 if (transport == TRANSPORT_AVTP) {
                     int8_t d8 = (int8_t)((uint8_t)seq - (uint8_t)last_seq);
                     if (d8 > 1) lost += (uint64_t)(d8 - 1);
+                } else if (transport == TRANSPORT_RTP) {
+                    int16_t d16 = (int16_t)((uint16_t)seq - (uint16_t)last_seq);
+                    if (d16 > 1) lost += (uint64_t)(d16 - 1);
                 } else {
                     int32_t delta = (int32_t)(seq - last_seq);
                     if (delta > 1) lost += (uint64_t)(delta - 1);
@@ -746,10 +804,10 @@ int main(int argc, char **argv)
                 /* Prefer the ACMP-announced talker MAC over learning from
                  * the first frame: Hive's Connect should steer us, not the
                  * first arriving packet (which might be a stray from
-                 * another talker on the same segment). IP mode still
-                 * learns from src_addr because AVDECC is L2-only. */
+                 * another talker on the same segment). IP / RTP modes
+                 * learn from src_addr because AVDECC is L2/AVTP-only. */
                 int used_avdecc = 0;
-                if (transport != TRANSPORT_IP) {
+                if (transport != TRANSPORT_IP && transport != TRANSPORT_RTP) {
                     pthread_mutex_lock(&g_avdecc_mu);
                     if (g_avdecc_peer_valid) {
                         memcpy(talker_mac, g_avdecc_peer_mac, 6);
@@ -757,14 +815,14 @@ int main(int argc, char **argv)
                     }
                     pthread_mutex_unlock(&g_avdecc_mu);
                 }
-                if (transport == TRANSPORT_IP) {
+                if (transport == TRANSPORT_IP || transport == TRANSPORT_RTP) {
                     memcpy(&talker_addr, &src_addr, src_addrlen);
                     talker_addr_len = src_addrlen;
                 } else if (!used_avdecc) {
                     const struct ether_header *eth = (const struct ether_header *)buf;
                     memcpy(talker_mac, eth->ether_shost, 6);
                 }
-                if (transport != TRANSPORT_IP) {
+                if (transport != TRANSPORT_IP && transport != TRANSPORT_RTP) {
                     memcpy(fb_eth->ether_dhost, talker_mac, 6);
                     memcpy(fb_to_ll.sll_addr, talker_mac, 6);
                 }
@@ -854,7 +912,10 @@ int main(int argc, char **argv)
         }
 
 check_feedback:
-        if (!feedback_enabled || !have_talker) {
+        /* RTP/AES67 doesn't use AOEther's Mode C feedback — AES67 devices
+         * expect PTPv2 for clocking and will discard our 0x88B6 frames.
+         * Skip emission entirely to avoid spraying unsolicited packets. */
+        if (!feedback_enabled || !have_talker || transport == TRANSPORT_RTP) {
             continue;
         }
 

--- a/talker/Makefile
+++ b/talker/Makefile
@@ -14,6 +14,7 @@ SRCS      := \
     src/audio_source_dsf.c \
     ../common/packet.c \
     ../common/avtp.c \
+    ../common/rtp.c \
     ../common/avdecc.c
 
 # AVDECC entity (M7 Phase B) is optional. See receiver/Makefile for
@@ -31,7 +32,7 @@ endif
 .PHONY: all clean
 all: $(BUILD)/talker
 
-$(BUILD)/talker: $(SRCS) src/audio_source.h ../common/packet.h ../common/avtp.h ../common/avdecc.h | $(BUILD)
+$(BUILD)/talker: $(SRCS) src/audio_source.h ../common/packet.h ../common/avtp.h ../common/rtp.h ../common/avdecc.h | $(BUILD)
 	$(LINK) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -2,6 +2,7 @@
 #include "avdecc.h"
 #include "avtp.h"
 #include "packet.h"
+#include "rtp.h"
 
 #include <pthread.h>
 
@@ -27,11 +28,17 @@
 
 /* Stream parameters. Channels, rate, and sample format are all runtime-
  * configured from M6 on. The "rate" field generalizes to "samples or DSD-
- * bytes per second per channel" so the per-microframe payload math (rate /
- * 8000) works uniformly across PCM and native DSD. */
-#define STREAM_ID             0x0001
-#define PACKET_PERIOD_NS      125000L          /* 125 µs = 1 USB microframe */
-#define MICROFRAMES_PER_MS    8
+ * bytes per second per channel" so the per-packet payload math works
+ * uniformly across PCM and native DSD.
+ *
+ * Modes 1/2/3 run at 8000 pps (125 µs per packet, one USB microframe);
+ * Mode 4 (RTP/AES67) runs at PTIME — default 1 ms (1000 pps) per AES67,
+ * optional 125 µs via --ptime. PACKET_PERIOD_DEFAULT_NS captures the
+ * Modes-1-3 default; the runtime-resolved `packet_period_ns` below is
+ * used everywhere else. */
+#define STREAM_ID                    0x0001
+#define PACKET_PERIOD_DEFAULT_NS     125000L
+#define PACKET_PERIOD_AES67_1MS_NS   1000000L
 
 #define DEFAULT_CHANNELS      2
 #define DEFAULT_RATE_HZ       48000
@@ -57,6 +64,7 @@ enum transport_mode {
     TRANSPORT_L2 = 0,    /* raw Ethernet, AF_PACKET, EtherType 0x88B5/0x88B6 */
     TRANSPORT_IP = 1,    /* UDP over IPv4/v6, magic-byte disambiguation */
     TRANSPORT_AVTP = 2,  /* IEEE 1722 AVTP AAF, EtherType 0x22F0 (Milan) */
+    TRANSPORT_RTP = 3,   /* RTP/AES67 over UDP (Mode 4, M9 Phase A) */
 };
 
 /* Safety clamp on feedback-derived rate: ±1000 ppm of nominal. */
@@ -194,6 +202,11 @@ static void usage(const char *prog)
         "    --port N                        UDP port, default %d\n"
         "  --transport avtp             IEEE 1722 AAF, Milan interop (Mode 2, M5)\n"
         "    --dest-mac AA:BB:CC:DD:EE:FF    (required; unicast or AVTP multicast)\n"
+        "  --transport rtp              RTP/AES67 over UDP (Mode 4, M9 Phase A)\n"
+        "    --dest-ip X.Y.Z.W | v6:literal  (required; 239.X.X.X typical)\n"
+        "    --port N                        UDP port, default 5004 (AES67)\n"
+        "    --ptime US                      packet time: 1000 (AES67 default)\n"
+        "                                    or 125 (low-latency profile)\n"
         "\n"
         "Source:\n"
         "  --source testtone|wav|alsa|dsdsilence|dsf\n"
@@ -242,6 +255,7 @@ int main(int argc, char **argv)
     int rate_hz = DEFAULT_RATE_HZ;
     enum transport_mode transport = TRANSPORT_L2;
     int udp_port = DEFAULT_UDP_PORT;
+    int ptime_us = 0;                 /* 0 = transport-default; user may set 125 or 1000 */
     int avdecc_enabled = 0;
     const char *entity_name = NULL;
 
@@ -251,6 +265,7 @@ int main(int argc, char **argv)
         { "dest-ip",   required_argument, 0, 'I' },
         { "transport", required_argument, 0, 'T' },
         { "port",      required_argument, 0, 'P' },
+        { "ptime",     required_argument, 0, 1001 },
         { "source",    required_argument, 0, 's' },
         { "file",      required_argument, 0, 'f' },
         { "capture",   required_argument, 0, 'c' },
@@ -272,9 +287,11 @@ int main(int argc, char **argv)
             if      (strcmp(optarg, "l2") == 0)   transport = TRANSPORT_L2;
             else if (strcmp(optarg, "ip") == 0)   transport = TRANSPORT_IP;
             else if (strcmp(optarg, "avtp") == 0) transport = TRANSPORT_AVTP;
-            else { fprintf(stderr, "talker: --transport must be l2, ip, or avtp\n"); return 2; }
+            else if (strcmp(optarg, "rtp") == 0)  transport = TRANSPORT_RTP;
+            else { fprintf(stderr, "talker: --transport must be l2, ip, avtp, or rtp\n"); return 2; }
             break;
         case 'P': udp_port = atoi(optarg); break;
+        case 1001: ptime_us = atoi(optarg); break;
         case 's': source = optarg; break;
         case 'f': wav_path = optarg; break;
         case 'c': capture_pcm = optarg; break;
@@ -299,13 +316,45 @@ int main(int argc, char **argv)
                 transport == TRANSPORT_L2 ? "l2" : "avtp");
         return 2;
     }
-    if (transport == TRANSPORT_IP && !dest_ip_s) {
-        fprintf(stderr, "talker: --dest-ip required for --transport ip\n");
+    if ((transport == TRANSPORT_IP || transport == TRANSPORT_RTP) && !dest_ip_s) {
+        fprintf(stderr, "talker: --dest-ip required for --transport %s\n",
+                transport == TRANSPORT_IP ? "ip" : "rtp");
         return 2;
+    }
+    if (transport == TRANSPORT_RTP && udp_port == DEFAULT_UDP_PORT) {
+        /* AES67's registered RTP port is 5004; retarget the default when
+         * the user hasn't set --port explicitly. */
+        udp_port = RTP_DEFAULT_PORT;
     }
     if (udp_port < 1 || udp_port > 65535) {
         fprintf(stderr, "talker: --port out of range\n");
         return 2;
+    }
+
+    /* Packet cadence. Modes 1/2/3 run at USB-microframe cadence (125 µs).
+     * Mode 4 (RTP/AES67) uses PTIME — default 1 ms, optional 125 µs for
+     * the low-latency AES67 profile. Other PTIME values (250 µs, 333 µs)
+     * exist in the spec but aren't supported here yet. */
+    long packet_period_ns;
+    if (transport == TRANSPORT_RTP) {
+        if (ptime_us == 0)                         ptime_us = RTP_PTIME_US_1MS;
+        if (ptime_us != RTP_PTIME_US_1MS &&
+            ptime_us != RTP_PTIME_US_125US) {
+            fprintf(stderr,
+                    "talker: --ptime %d unsupported for RTP "
+                    "(use 1000 for AES67 default or 125 for low-latency)\n",
+                    ptime_us);
+            return 2;
+        }
+        packet_period_ns = (long)ptime_us * 1000L;
+    } else {
+        if (ptime_us != 0 && ptime_us != 125) {
+            fprintf(stderr,
+                    "talker: --ptime only applies to --transport rtp "
+                    "(modes 1/2/3 are locked to 125 µs microframe cadence)\n");
+            return 2;
+        }
+        packet_period_ns = PACKET_PERIOD_DEFAULT_NS;
     }
     if (channels < 1 || channels > 64) {
         fprintf(stderr, "talker: --channels must be 1..64 (got %d)\n", channels);
@@ -328,6 +377,10 @@ int main(int argc, char **argv)
     }
     if (transport == TRANSPORT_AVTP && fmt.is_dsd) {
         fprintf(stderr, "talker: AVTP AAF does not carry DSD; use --transport l2 or ip with --format dsd*\n");
+        return 2;
+    }
+    if (transport == TRANSPORT_RTP && fmt.is_dsd) {
+        fprintf(stderr, "talker: AES67 RTP is PCM-only; use --transport l2 or ip with --format dsd*\n");
         return 2;
     }
     const uint8_t format_code = fmt.code;
@@ -359,21 +412,27 @@ int main(int argc, char **argv)
      * (u8) or the MTU would otherwise overflow. See docs/wire-format.md
      * §"Cadence and fragmentation".
      *
-     * AVTP AAF does not fragment — splitting an AAF stream across multiple
-     * 1722 frames per microframe breaks interop with strict Milan listeners.
-     * AAF configs that overflow MTU are rejected at startup. */
-    const size_t proto_hdr_len = (transport == TRANSPORT_AVTP) ? AVTP_HDR_LEN
-                                                               : AOE_HDR_LEN;
-    const double nominal_spm = (double)rate_hz / 1000.0 / MICROFRAMES_PER_MS;
+     * AVTP AAF (Mode 2) and RTP/AES67 (Mode 4) do not fragment — splitting
+     * across multiple frames per packet interval breaks interop with strict
+     * Milan / AES67 listeners respectively. Those modes reject MTU-
+     * overflowing configurations at startup. */
+    const size_t proto_hdr_len =
+        (transport == TRANSPORT_AVTP) ? AVTP_HDR_LEN :
+        (transport == TRANSPORT_RTP)  ? RTP_HDR_LEN  :
+                                        AOE_HDR_LEN;
+    /* nominal_spm is now "samples per packet" in whatever cadence the
+     * transport uses. Legacy name kept to minimize diff churn. */
+    const double nominal_spm =
+        (double)rate_hz * (double)packet_period_ns / 1e9;
     const int max_samples_per_microframe = (int)(nominal_spm + 0.5) + 4;
     const size_t max_microframe_payload =
         (size_t)max_samples_per_microframe * channels * bytes_per_sample;
 
     /* Per-fragment upper bound on payload_count: clamped by the u8 field
      * and by the worst-case per-fragment MTU budget. Fragmentation is an
-     * AOE-only path, so we compute this for L2/IP only. */
+     * AOE-only path (Modes 1 / 3). */
     int max_frag_pc = 0;
-    if (transport != TRANSPORT_AVTP) {
+    if (transport != TRANSPORT_AVTP && transport != TRANSPORT_RTP) {
         const size_t per_ch_unit = (size_t)channels * bytes_per_sample;
         if (per_ch_unit == 0) {
             fprintf(stderr, "talker: invalid per-channel unit\n");
@@ -392,30 +451,32 @@ int main(int argc, char **argv)
         max_frag_pc = (int)mtu_budget_pc;
     }
 
-    /* Startup MTU check. AVTP always rejects overflow; AOE only rejects the
-     * pathological "one sample doesn't fit" case handled above. */
-    if (transport == TRANSPORT_AVTP &&
+    /* Startup MTU check for non-fragmenting transports. */
+    if ((transport == TRANSPORT_AVTP || transport == TRANSPORT_RTP) &&
         max_microframe_payload + proto_hdr_len > ETH_MTU_PAYLOAD) {
+        const char *mode_name =
+            transport == TRANSPORT_AVTP ? "AVTP AAF" : "RTP/AES67";
         fprintf(stderr,
-                "talker: ch=%d rate=%d under AVTP AAF needs %zu-byte payload "
+                "talker: ch=%d rate=%d under %s needs %zu-byte payload "
                 "— exceeds 1500-byte MTU.\n"
-                "  AAF does not support per-microframe fragmentation (would "
-                "break Milan interop). Try --transport l2 or --transport ip, "
-                "or reduce channels / rate.\n",
-                channels, rate_hz,
+                "  This transport does not support per-packet fragmentation "
+                "(would break listener interop). Try --transport l2 or "
+                "--transport ip, or reduce channels / rate.\n",
+                channels, rate_hz, mode_name,
                 max_microframe_payload + proto_hdr_len);
         return 2;
     }
 
     /* Per-frame buffer sizing:
      *   - `frame` holds one transmission unit = Ethernet header + proto
-     *     header + one fragment's payload (for AOE) or one full microframe
-     *     (for AVTP).
-     *   - `audio_buf` holds one full microframe's audio bytes, read from
-     *     the source in one `read()` call and then sliced into fragments.
-     *     AVTP reads into this too and copies once into `frame`. */
+     *     header + one fragment's payload (for AOE) or one full packet
+     *     (for AVTP / RTP).
+     *   - `audio_buf` holds one full packet-interval's audio bytes, read
+     *     from the source in one `read()` call and then sliced into
+     *     fragments for AOE. AVTP / RTP read into this too and copy once
+     *     into `frame`. */
     const size_t max_frag_payload =
-        (transport == TRANSPORT_AVTP)
+        (transport == TRANSPORT_AVTP || transport == TRANSPORT_RTP)
             ? max_microframe_payload
             : ((size_t)max_frag_pc * channels * bytes_per_sample);
     const size_t max_frame = sizeof(struct ether_header) + proto_hdr_len + max_frag_payload;
@@ -452,6 +513,7 @@ int main(int argc, char **argv)
          * The per-packet egress path swaps in the ACMP MAC before each
          * send, so the zero placeholder never reaches the wire. */
     } else {
+        /* IP (Mode 3) and RTP (Mode 4) both take a dest IP. */
         struct in_addr v4;
         struct in6_addr v6;
         if (inet_pton(AF_INET, dest_ip_s, &v4) == 1) {
@@ -657,8 +719,8 @@ int main(int argc, char **argv)
     int tfd = timerfd_create(CLOCK_MONOTONIC, 0);
     if (tfd < 0) { perror("timerfd_create"); return 1; }
     struct itimerspec its = {
-        .it_interval = { 0, PACKET_PERIOD_NS },
-        .it_value    = { 0, PACKET_PERIOD_NS },
+        .it_interval = { 0, packet_period_ns },
+        .it_value    = { 0, packet_period_ns },
     };
     if (timerfd_settime(tfd, 0, &its, NULL) < 0) {
         perror("timerfd_settime");
@@ -669,9 +731,14 @@ int main(int argc, char **argv)
     signal(SIGTERM, on_signal);
 
     /* AVDECC entity (M7 Phase B). Talker publishes a STREAM_OUTPUT so
-     * Milan controllers can discover and bind it. Scaffolding only
-     * in step 1 — descriptor tree and ACMP CONNECT_TX handling arrive
-     * in step 2. */
+     * Milan controllers can discover and bind it. AVDECC is L2/AVTP-only;
+     * it has no meaning under RTP/AES67 (Ravenna uses SAP, not AVDECC). */
+    if (avdecc_enabled && transport == TRANSPORT_RTP) {
+        fprintf(stderr,
+                "talker: --avdecc has no effect under --transport rtp "
+                "(AES67 uses SAP/SDP for discovery; AVDECC is Milan-only)\n");
+        avdecc_enabled = 0;
+    }
     struct aoether_avdecc *avdecc = NULL;
     if (avdecc_enabled) {
         struct aoether_avdecc_config cfg = {
@@ -696,7 +763,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    /* L2 / AVTP have an Ethernet header prefix; IP mode does not. */
+    /* L2 / AVTP have an Ethernet header prefix; IP and RTP do not
+     * (kernel adds IP/UDP when sendto'ing on a DGRAM socket). */
     if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
         struct ether_header *eth = (struct ether_header *)frame;
         memcpy(eth->ether_dhost, dest_mac, 6);
@@ -708,9 +776,13 @@ int main(int argc, char **argv)
         (frame + sizeof(struct ether_header));
     struct avtp_aaf_hdr *avtp_hdr_p = (struct avtp_aaf_hdr *)
         (frame + sizeof(struct ether_header));
+    struct rtp_hdr      *rtp_hdr_p  = (struct rtp_hdr *)
+        (frame + sizeof(struct ether_header));
     uint8_t *payload = frame + sizeof(struct ether_header) + proto_hdr_len;
-    /* IP mode skips the 14-byte Ethernet-header prefix on the wire. */
-    const size_t tx_offset = (transport == TRANSPORT_IP) ? sizeof(struct ether_header) : 0;
+    /* IP and RTP skip the 14-byte Ethernet-header prefix on the wire. */
+    const size_t tx_offset =
+        (transport == TRANSPORT_IP || transport == TRANSPORT_RTP)
+            ? sizeof(struct ether_header) : 0;
 
     /* AVTP stream_id convention: source MAC in high 6 bytes, our 16-bit
      * STREAM_ID in the low 2. Milan AVDECC normally allocates these via
@@ -725,27 +797,56 @@ int main(int argc, char **argv)
         | (uint64_t)STREAM_ID;
     uint8_t avtp_seq8 = 0;
 
+    /* RTP/AES67 state: SSRC is a stable 32-bit random-ish identifier.
+     * Mint it from the low 4 bytes of our MAC XOR with our STREAM_ID so
+     * it survives talker restarts with the same config. Controllers use
+     * SSRC to dedupe sources on the same (mcast, port) tuple. */
+    const uint32_t rtp_ssrc =
+        (((uint32_t)src_mac[2] << 24) |
+         ((uint32_t)src_mac[3] << 16) |
+         ((uint32_t)src_mac[4] <<  8) |
+          (uint32_t)src_mac[5])
+        ^ (uint32_t)STREAM_ID;
+    /* RTP timestamp advances by samples-per-packet in the stream's media
+     * clock ticks. Starts at a random-ish value to avoid collisions and
+     * to match AES67's expectation that timestamps reflect media-clock
+     * state rather than wall-clock zero. We derive from a local monotonic
+     * timestamp at start; once PTPv2 lands (M9 Phase C) this becomes the
+     * PTP-disciplined timestamp. */
+    struct timespec rtp_start_ts;
+    clock_gettime(CLOCK_MONOTONIC, &rtp_start_ts);
+    uint32_t rtp_timestamp = (uint32_t)(
+        (uint64_t)rtp_start_ts.tv_sec * (uint64_t)rate_hz +
+        ((uint64_t)rtp_start_ts.tv_nsec * (uint64_t)rate_hz) / 1000000000ull);
+    uint16_t rtp_seq16 = 0;
+
     /* Predicted fragment count for the nominal microframe. K=1 is the
      * common case; larger values report the split that will be applied
-     * to DSD512+ and high-rate multichannel PCM. AVTP reports "no-frag". */
+     * to DSD512+ and high-rate multichannel PCM. AVTP/RTP report 0
+     * (they never fragment). */
     int nominal_K = 1;
-    if (transport != TRANSPORT_AVTP && max_frag_pc > 0) {
+    if (transport != TRANSPORT_AVTP && transport != TRANSPORT_RTP &&
+        max_frag_pc > 0) {
         int nominal_pc = (int)(nominal_spm + 0.5);
         if (nominal_pc < 1) nominal_pc = 1;
         nominal_K = (nominal_pc + max_frag_pc - 1) / max_frag_pc;
     }
+
+    const double pps = 1e9 / (double)packet_period_ns;
+    const int feedback_enabled_for_transport =
+        (transport != TRANSPORT_RTP);
 
     if (transport == TRANSPORT_L2 || transport == TRANSPORT_AVTP) {
         const char *label = (transport == TRANSPORT_AVTP) ? "avtp" : "l2";
         fprintf(stderr,
                 "talker: transport=%s iface=%s ifindex=%d\n"
                 "        src=%02x:%02x:%02x:%02x:%02x:%02x dst=%02x:%02x:%02x:%02x:%02x:%02x\n"
-                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_frag_pc=%d frags/microframe=%d max_frame=%zuB feedback=on\n",
+                "        fmt=%s ch=%d rate=%d pps=%.0f nominal_spp=%.2f max_frag_pc=%d frags/packet=%d max_frame=%zuB feedback=on\n",
                 label, iface, ifindex,
                 src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
                 dest_mac[0], dest_mac[1], dest_mac[2], dest_mac[3], dest_mac[4], dest_mac[5],
                 transport == TRANSPORT_AVTP ? "AAF_INT24(BE)" : format_s,
-                channels, rate_hz, nominal_spm,
+                channels, rate_hz, pps, nominal_spm,
                 transport == TRANSPORT_AVTP ? 0 : max_frag_pc,
                 nominal_K, max_frame);
     } else {
@@ -759,17 +860,21 @@ int main(int argc, char **argv)
                       &((struct sockaddr_in6 *)&dest_ss)->sin6_addr,
                       ip_str, sizeof(ip_str));
         }
+        const char *label = (transport == TRANSPORT_RTP) ? "rtp" : "ip";
         fprintf(stderr,
-                "talker: transport=ip dest=%s:%d family=%s %s\n"
+                "talker: transport=%s dest=%s:%d family=%s %s\n"
                 "        iface=%s ifindex=%d\n"
-                "        fmt=%s ch=%d rate=%d pps=8000 nominal_spp=%.2f max_frag_pc=%d frags/microframe=%d max_payload=%zuB feedback=on\n",
-                ip_str, udp_port,
+                "        fmt=%s ch=%d rate=%d pps=%.0f nominal_spp=%.2f max_frag_pc=%d frags/packet=%d max_payload=%zuB feedback=%s%s\n",
+                label, ip_str, udp_port,
                 dest_family == AF_INET ? "v4" : "v6",
                 dest_is_multicast ? "multicast" : "unicast",
                 iface, ifindex,
-                format_s, channels, rate_hz,
-                nominal_spm, max_frag_pc, nominal_K,
-                max_frame - sizeof(struct ether_header));
+                transport == TRANSPORT_RTP ? "L24(BE)" : format_s,
+                channels, rate_hz,
+                pps, nominal_spm, max_frag_pc, nominal_K,
+                max_frame - sizeof(struct ether_header),
+                feedback_enabled_for_transport ? "on" : "off",
+                transport == TRANSPORT_RTP ? " (AES67 relies on PTPv2)" : "");
     }
 
     /* Mode C talker state: current target samples-per-microframe, fractional
@@ -797,7 +902,11 @@ int main(int argc, char **argv)
     uint64_t fb_rx = 0, fb_ignored = 0;
 
     while (!g_stop) {
-        /* 1. Drain any pending feedback frames (non-blocking). */
+        /* 1. Drain any pending feedback frames (non-blocking). RTP/AES67
+         * doesn't use AOEther's UAC2-shape feedback (AES67 devices rely
+         * on PTPv2 for clocking), so we skip the drain and the
+         * rate-recompute for that transport. */
+        if (transport == TRANSPORT_RTP) goto skip_feedback;
         for (;;) {
             uint8_t fb_buf[128];
             struct sockaddr_storage src_addr;
@@ -828,7 +937,7 @@ int main(int argc, char **argv)
 
             uint32_t q = ntohl(fh->value);
             double spms = (double)q / 65536.0;
-            double new_spm = spms / (double)MICROFRAMES_PER_MS;
+            double new_spm = spms * ((double)packet_period_ns / 1e6);
 
             double max_spm = nominal_spm * (1.0 + RATE_CLAMP_PPM * 1e-6);
             double min_spm = nominal_spm * (1.0 - RATE_CLAMP_PPM * 1e-6);
@@ -912,11 +1021,13 @@ int main(int argc, char **argv)
         }
         if (have_any) {
             double spms = (double)min_q / 65536.0;
-            samples_per_microframe = spms / (double)MICROFRAMES_PER_MS;
+            samples_per_microframe = spms * ((double)packet_period_ns / 1e6);
         } else {
             samples_per_microframe = nominal_spm;
         }
 
+skip_feedback:
+        (void)0;   /* null statement so a C compiler accepts the label. */
         /* 3. Wait for timer tick(s). */
         uint64_t ticks;
         ssize_t r = read(tfd, &ticks, sizeof(ticks));
@@ -952,11 +1063,11 @@ int main(int argc, char **argv)
                 break;
             }
 
-            /* Fragment count and per-fragment pc distribution. AVTP is
-             * always K=1; AOE uses max_frag_pc computed at startup. */
+            /* Fragment count and per-fragment pc distribution. AVTP / RTP
+             * are always K=1; AOE uses max_frag_pc computed at startup. */
             int K;
             int base, rem;
-            if (transport == TRANSPORT_AVTP) {
+            if (transport == TRANSPORT_AVTP || transport == TRANSPORT_RTP) {
                 K = 1;
                 base = pc;
                 rem  = 0;
@@ -968,12 +1079,11 @@ int main(int argc, char **argv)
             }
 
             /* If AVDECC bound us this tick, steer the destination for all
-             * fragments of this microframe together. Taking the snapshot
-             * once per microframe (not per fragment) keeps a group's
-             * fragments on the same peer even if an unbind races a send. */
+             * fragments of this microframe together. AVDECC is an L2 / AVTP
+             * thing; IP and RTP modes keep their static --dest-ip. */
             int steer_avdecc = 0;
             uint8_t avdecc_mac_snap[6];
-            if (transport != TRANSPORT_IP) {
+            if (transport != TRANSPORT_IP && transport != TRANSPORT_RTP) {
                 pthread_mutex_lock(&g_avdecc_mu);
                 if (g_avdecc_dest_valid) {
                     memcpy(avdecc_mac_snap, g_avdecc_dest_mac, 6);
@@ -1014,6 +1124,19 @@ int main(int argc, char **argv)
                                        (uint16_t)channels,
                                        24,                   /* bit_depth */
                                        (uint16_t)frag_payload_bytes);
+                } else if (transport == TRANSPORT_RTP) {
+                    /* AES67 L24 samples are big-endian on the wire; ALSA
+                     * is LE. Swap in place, same as AVTP. */
+                    rtp_swap24_inplace(payload,
+                                       (size_t)frag_pc * (size_t)channels);
+                    rtp_hdr_build(rtp_hdr_p,
+                                  RTP_DEFAULT_PT_L24,
+                                  rtp_seq16++,
+                                  rtp_timestamp,
+                                  rtp_ssrc);
+                    /* Advance the media clock by one packet's samples for
+                     * the next emission. */
+                    rtp_timestamp += (uint32_t)frag_pc;
                 } else {
                     const uint8_t flags =
                         (k == K - 1) ? AOE_FLAG_LAST_IN_GROUP : 0;
@@ -1026,7 +1149,8 @@ int main(int argc, char **argv)
                     sizeof(struct ether_header) + proto_hdr_len + frag_payload_bytes;
 
                 ssize_t sent;
-                if (transport == TRANSPORT_IP) {
+                if (transport == TRANSPORT_IP ||
+                    transport == TRANSPORT_RTP) {
                     sent = sendto(data_sock, frame + tx_offset,
                                   frame_len_total - tx_offset, 0,
                                   (struct sockaddr *)&dest_ss, dest_ss_len);


### PR DESCRIPTION
## Summary

Lands Mode 4 — PCM audio as RFC 3550 RTP with an RFC 3190 L24 payload — the data-plane profile AES67 / Ravenna devices expect. Adds `--transport rtp` on both talker and receiver alongside the existing `l2` / `ip` / `avtp` modes.

```sh
# Talker → AES67 listener (default PTIME=1 ms):
sudo ./build/talker --iface eno1 --transport rtp \
                    --dest-ip 239.69.1.10 --port 5004 \
                    --source testtone --channels 2 --rate 48000

# AOEther receiver ← AES67 talker:
sudo ./build/receiver --iface eth0 --dac hw:... \
                      --transport rtp --group 239.69.1.10 --port 5004 \
                      --channels 2 --rate 48000
```

This is **Phase A** of M9 — the RTP wire encoding only. SDP / SAP discovery (Phase B), PTPv2 timestamp discipline (Phase C), and end-to-end interop validation against `aes67-linux-daemon` / commercial gear (Phase D) are tracked separately.

## What's in the patch

- **New `common/rtp.{h,c}`** — 12-byte RTP header struct + builder/parser, plus in-place BE↔LE byte-swap helpers for L24 and L16.
- **Talker** — `--transport rtp`, `--ptime US` (1000 default, 125 optional for the AES67 low-latency profile). Timerfd period is parameterized on PTIME. RTP header built per packet with PT=96, monotonic 16-bit sequence, SSRC from iface MAC XOR stream ID, timestamp advancing by samples-per-packet from a `CLOCK_MONOTONIC` start. L24 bytes swapped from ALSA LE to wire BE on egress.
- **Receiver** — `--transport rtp`, RTP parse, L24 BE→LE swap, sequence-gap detection widened to 16-bit for RTP. Reuses the existing IP-mode UDP socket setup (including `--group` multicast membership).
- **Mode C feedback disabled under RTP** on both sides — AES67 devices expect PTPv2, not our UAC2-style 0x88B6 frames.
- **AVDECC + RTP rejected** on both sides (AVDECC is Milan; AES67 uses SAP/SDP).
- **Packet splitting disabled under RTP** — strict AES67 listeners don't reassemble, so MTU-overflowing configs are rejected at talker startup (same rule as AVTP).
- **DSD + RTP rejected** — AES67 is PCM-only.
- **Docs**: `wire-format.md` grows a Mode 4 section with header layout and PTIME table; `design.md` M9 restructured into Phase A (shipped) / B (open: SDP/SAP) / C (open: PTPv2) / D (hardware-blocked: interop); new `docs/recipe-aes67.md` operator recipe with sample SDP for manual interop with Dante / Merging / Neumann endpoints.

## Not in scope (Phase B+)

- SDP session description and SAP (RFC 2974) announcement.
- PTPv2 default-profile timestamp locking — the RTP timestamp is currently derived from `CLOCK_MONOTONIC`, not PTP. Strict AES67 listeners will tolerate this with drift visible over long sessions.
- Dynamic payload-type negotiation — PT=96 unconditionally.
- L16 as a user-facing `--format` option (wire helpers exist but the `--format` plumbing doesn't).

## Test plan

- [ ] `cd talker && make` and `cd receiver && make` on a Linux box build cleanly.
- [ ] Stereo 48 kHz L24 PTIME=1 ms: tcpdump shows RTP packets on UDP/5004 to 239.69.1.10 with V=2, PT=96, sequence increment 1, timestamp increment 48.
- [ ] Byte-swap: first three payload bytes of fragment 0 swap from ALSA-side LE to wire BE (confirm by comparing a synthesized constant against the capture).
- [ ] PTIME=125 µs low-latency: same stream, 8000 pps, timestamp increment 6.
- [ ] `--transport rtp --format dsd256` exits early with "AES67 RTP is PCM-only".
- [ ] `--transport avtp` regression unchanged.
- [ ] Smoke-test against `aes67-linux-daemon` using the sample SDP in `docs/recipe-aes67.md`.

Based on current `main` (post-#13 merge).
