### PR TITLE
M9 Phase E: full Ravenna interop (DXD + DoP, symmetric)

### DIFF
--- a/common/dop.c
+++ b/common/dop.c
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "dop.h"
+
+uint32_t dop_carrier_rate_for_dsd(uint32_t dsd_byte_rate)
+{
+    /* Carrier = DSD bit rate / 16 = DSD byte rate / 2. */
+    switch (dsd_byte_rate) {
+    case  352800u: return  176400u; /* DSD64  */
+    case  705600u: return  352800u; /* DSD128 */
+    case 1411200u: return  705600u; /* DSD256 — Merging cap */
+    case 2822400u: return 1411200u; /* DSD512 — out of AES67/Ravenna spec */
+    default:       return 0u;
+    }
+}
+
+uint32_t dop_dsd_byte_rate_for_carrier(uint32_t carrier_hz)
+{
+    switch (carrier_hz) {
+    case  176400u: return  352800u; /* DSD64  */
+    case  352800u: return  705600u; /* DSD128 */
+    case  705600u: return 1411200u; /* DSD256 */
+    case 1411200u: return 2822400u; /* DSD512 */
+    default:       return 0u;
+    }
+}
+
+void dop_encode(const uint8_t *dsd_bytes,
+                uint8_t       *l24_out,
+                int            channels,
+                size_t         n_frames,
+                struct dop_enc_state *st)
+{
+    uint8_t parity = st->marker_parity;
+    for (size_t f = 0; f < n_frames; f++) {
+        const uint8_t marker = parity ? DOP_MARKER_ODD : DOP_MARKER_EVEN;
+        for (int c = 0; c < channels; c++) {
+            /* Two DSD bytes per channel per L24 frame, sourced from
+             * AOE-wire layout (byte_i * channels + c). The earlier
+             * byte (older in time) goes to L24 byte 1 (just below the
+             * marker); the later byte goes to L24 byte 2 (LSB). */
+            const size_t dsd_idx_a = ((2u * f) + 0u) * (size_t)channels + (size_t)c;
+            const size_t dsd_idx_b = ((2u * f) + 1u) * (size_t)channels + (size_t)c;
+            const size_t l24_idx = (f * (size_t)channels + (size_t)c) * 3u;
+            l24_out[l24_idx + 0] = marker;
+            l24_out[l24_idx + 1] = dsd_bytes[dsd_idx_a];
+            l24_out[l24_idx + 2] = dsd_bytes[dsd_idx_b];
+        }
+        parity ^= 1u;
+    }
+    st->marker_parity = parity;
+}
+
+size_t dop_decode(const uint8_t *l24_in,
+                  uint8_t       *dsd_bytes_out,
+                  int            channels,
+                  size_t         n_frames,
+                  struct dop_dec_state *st)
+{
+    uint8_t expected = st->marker_parity;
+    size_t  good = 0;
+    for (size_t f = 0; f < n_frames; f++) {
+        const uint8_t want = expected ? DOP_MARKER_ODD : DOP_MARKER_EVEN;
+        const uint8_t alt  = expected ? DOP_MARKER_EVEN : DOP_MARKER_ODD;
+        /* Use channel 0's marker as the canonical one for this frame.
+         * The spec requires all channels of a frame to carry the same
+         * marker, but we don't fail the frame on a mismatch because
+         * some bridges silently corrupt one channel — better to keep
+         * decoding and let the audio side surface a defect than to drop
+         * the frame entirely. */
+        const uint8_t got = l24_in[(f * (size_t)channels + 0u) * 3u];
+        int frame_ok = 0;
+        if (got == want) {
+            frame_ok = 1;
+        } else if (got == alt) {
+            /* One-frame slip — accept and resync parity. */
+            expected ^= 1u;
+            frame_ok = 1;
+        }
+        if (frame_ok) {
+            good++;
+            if (!st->locked) st->locked = 1;
+        }
+        for (int c = 0; c < channels; c++) {
+            const size_t l24_idx = (f * (size_t)channels + (size_t)c) * 3u;
+            const size_t dsd_idx_a = ((2u * f) + 0u) * (size_t)channels + (size_t)c;
+            const size_t dsd_idx_b = ((2u * f) + 1u) * (size_t)channels + (size_t)c;
+            dsd_bytes_out[dsd_idx_a] = l24_in[l24_idx + 1];
+            dsd_bytes_out[dsd_idx_b] = l24_in[l24_idx + 2];
+        }
+        expected ^= 1u;
+    }
+    st->marker_parity = expected;
+    return good;
+}
+
+int dop_detect(const uint8_t *l24_in, int channels, size_t n_frames)
+{
+    if (n_frames < 2 || channels < 1) return 0;
+    /* Pick a starting parity from frame 0's MSB; demand frame 1 carries
+     * the opposite marker; demand all subsequent frames continue the
+     * alternation. Demand all channels of every frame share the marker. */
+    const uint8_t m0 = l24_in[0];
+    if (m0 != DOP_MARKER_EVEN && m0 != DOP_MARKER_ODD) return 0;
+    const uint8_t m1 = l24_in[(size_t)channels * 3u];
+    if (m1 == m0) return 0;
+    if (m1 != DOP_MARKER_EVEN && m1 != DOP_MARKER_ODD) return 0;
+    uint8_t expected = m0;
+    for (size_t f = 0; f < n_frames; f++) {
+        for (int c = 0; c < channels; c++) {
+            const size_t idx = (f * (size_t)channels + (size_t)c) * 3u;
+            if (l24_in[idx] != expected) return 0;
+        }
+        expected = (expected == DOP_MARKER_EVEN) ? DOP_MARKER_ODD
+                                                 : DOP_MARKER_EVEN;
+    }
+    return 1;
+}

--- a/common/dop.h
+++ b/common/dop.h
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* DoP (DSD-over-PCM) v1.1 encoder / decoder, used by Mode 4 (RTP/AES67)
+ * to carry native DSD inside an L24 PCM carrier — the standard Ravenna
+ * mechanism for DSD transport. Spec:
+ *
+ *   https://dsd-guide.com/sites/default/files/white-papers/DoP_open_Standard_1v1.pdf
+ *
+ * One DoP frame = one L24 PCM sample per channel, 24 bits laid out as:
+ *
+ *   byte 0 (MSB): marker, 0xFA on even frames and 0x05 on odd frames
+ *                 (or vice versa — listeners detect either polarity)
+ *   byte 1     : 8 DSD bits, MSB-first, oldest-first within the byte
+ *   byte 2     : 8 more DSD bits, MSB-first
+ *
+ * So each L24 frame at the carrier rate carries 16 DSD bits per channel.
+ * The carrier rate is therefore (DSD bit rate / 16):
+ *
+ *   DSD64  ( 2.8224 MHz)  →  176_400 Hz L24 carrier
+ *   DSD128 ( 5.6448 MHz)  →  352_800 Hz L24 carrier  (= DXD rate)
+ *   DSD256 (11.2896 MHz)  →  705_600 Hz L24 carrier  (Merging cap)
+ *   DSD512 (22.5792 MHz)  → 1_411_200 Hz L24 carrier (out of AES67/Ravenna
+ *                                                     spec; supported for
+ *                                                     non-Merging gear)
+ *
+ * AOEther's native-DSD source path produces DSD as MSB-first bytes,
+ * channel-interleaved at byte granularity (matching SND_PCM_FORMAT_DSD_U8
+ * and the AOE wire layout — index `byte_i * channels + c`). The encoder
+ * and decoder use this same layout for their DSD byte I/O so they can
+ * sit directly between the DSD source/sink path and the RTP wire path
+ * without an extra transpose. Each DoP L24 frame consumes / produces
+ * two consecutive DSD-byte rows (i.e. `byte_i = 2*f` and `byte_i = 2*f+1`)
+ * for every channel.
+ *
+ * The marker alternates per L24 frame (i.e. per pair of DSD bytes), and
+ * is the *same* marker across all channels of a given frame. The encoder
+ * tracks parity in caller-supplied state so streaming across packet
+ * boundaries works.
+ *
+ * On the wire AOEther emits L24 in network byte order (RTP/AES67 spec):
+ * the marker byte must be sent first (most-significant byte of the L24
+ * sample). The encoder writes its output in big-endian L24 directly so
+ * callers can hand the buffer to the RTP egress path with no further
+ * byte-swap. Decoder accepts BE input and writes native-DSD output. */
+
+/* DoP marker bytes. The spec calls these "FA" and "05"; emitting either
+ * polarity is acceptable to listeners — they look for the alternation,
+ * not a starting phase. AOEther emits FA on even frames, 05 on odd. */
+#define DOP_MARKER_EVEN    0xFAu
+#define DOP_MARKER_ODD     0x05u
+
+/* L24 carrier rate (Hz) for a given DSD byte rate (DSD bit rate / 8).
+ * Returns 0 if `dsd_byte_rate` is not a recognized DSD rate. */
+uint32_t dop_carrier_rate_for_dsd(uint32_t dsd_byte_rate);
+
+/* Inverse of dop_carrier_rate_for_dsd: returns the DSD byte rate that
+ * corresponds to a DoP-carrying L24 rate, or 0 if `carrier_hz` isn't a
+ * standard DoP carrier. Used by the receiver to detect-and-classify an
+ * incoming L24 stream when --unwrap-dop is set. */
+uint32_t dop_dsd_byte_rate_for_carrier(uint32_t carrier_hz);
+
+/* Encoder state. Caller zero-initializes once per stream and passes the
+ * same pointer on every call so marker parity is maintained across packet
+ * boundaries. Not thread-safe; one encoder per stream. */
+struct dop_enc_state {
+    uint8_t  marker_parity;  /* 0 = next frame uses MARKER_EVEN, 1 = ODD */
+};
+
+/* Encode `n_frames` L24 carrier frames from interleaved DSD bytes.
+ *
+ *   dsd_bytes  : input, AOE-wire layout — `byte_i * channels + c`,
+ *                MSB-first within each byte.
+ *                Length = n_frames * 2 * channels (each L24 frame eats
+ *                two DSD-byte rows × all channels).
+ *   l24_out    : output, big-endian L24 (24-bit big-endian PCM samples),
+ *                channels-interleaved. Length = n_frames * 3 * channels.
+ *   channels   : channel count (>= 1).
+ *   n_frames   : number of L24 carrier frames to produce.
+ *   st         : encoder state, advanced by n_frames mod 2.
+ */
+void dop_encode(const uint8_t *dsd_bytes,
+                uint8_t       *l24_out,
+                int            channels,
+                size_t         n_frames,
+                struct dop_enc_state *st);
+
+/* Decoder state. */
+struct dop_dec_state {
+    uint8_t  marker_parity;  /* expected parity for next frame */
+    uint8_t  locked;         /* 1 once we've seen a valid alternation */
+};
+
+/* Decode `n_frames` of big-endian L24 back to channels-interleaved DSD
+ * bytes (length n_frames * 2 * channels). Returns the number of frames
+ * whose markers passed the alternation check. A return of 0 means the
+ * input is not DoP (the receiver should treat it as plain L24 PCM).
+ *
+ * The decoder is permissive: a single bad marker doesn't abort, it just
+ * doesn't increment the good-frames count. The caller decides what to
+ * do (e.g. fall back to PCM passthrough after N bad frames in a row). */
+size_t dop_decode(const uint8_t *l24_in,
+                  uint8_t       *dsd_bytes_out,
+                  int            channels,
+                  size_t         n_frames,
+                  struct dop_dec_state *st);
+
+/* Detect whether a buffer of big-endian L24 samples is DoP without
+ * mutating any state. Returns 1 if the marker pattern (alternating
+ * 0xFA / 0x05 in the MSB across consecutive frames, same value across
+ * channels within a frame) is present for the full buffer; 0 otherwise.
+ * Useful at receiver startup to choose between passthrough vs unwrap. */
+int dop_detect(const uint8_t *l24_in, int channels, size_t n_frames);

--- a/docs/design.md
+++ b/docs/design.md
@@ -550,10 +550,21 @@ Ships in phases:
 
 **Phase D — [hardware-blocked] Interop validation.** Confirmed playback with `aes67-linux-daemon` (open-source reference), Merging ANEMAN / Anubis, a Dante-with-AES67-mode device, and a Neumann or similar Ravenna endpoint.
 
-**Documented constraints:**
-- AES67 is PCM only, so DSD streams remain on Modes 1 / 3 (with AoE header). The talker / receiver reject `--transport rtp --format dsd*` at startup.
+**Phase E — [shipped] Full Ravenna interop (DXD + DoP, symmetric).** Lifts the AES67-strict rate cap and the DSD reject so AOEther interops with the Merging-class Ravenna feature set.
+Talker `rate_supported()` and receiver `rate_supported()` both gain 352800 / 384000 (DXD PCM) and 705600 / 1411200 (DoP carriers).
+Native DSD over RTP rides as DoP-encoded L24 PCM at the carrier rate (DSD bit rate / 16) per the [DoP v1.1 spec](https://dsd-guide.com/sites/default/files/white-papers/DoP_open_Standard_1v1.pdf): alternating 0xFA / 0x05 marker in the most significant byte, two DSD bytes packed into the lower two bytes per channel per frame.
+Encoder + decoder live in `common/dop.{h,c}` (~150 LoC); DSD I/O uses AOE wire layout (`byte_i * channels + c`) so the same encoder feeds Modes 1/3 if that path is later activated.
+Talker auto-rounds the per-microframe DSD-byte count to even and carries any spare DSD byte forward via the existing fractional sample accumulator; the RTP timestamp clock advances at the L24 carrier rate.
+SDP advertises the carrier rate (e.g. `L24/176400/2` for DSD64-DoP) — DoP is content-level, not signaled at the SDP layer.
+Receiver supports two output modes for incoming DoP streams: **passthrough** (default) writes the BE-L24 stream to ALSA as `SND_PCM_FORMAT_S24_3LE` at the carrier rate and lets the DAC firmware see the marker pattern in the MSB and switch to DSD itself — works with any DoP-capable USB DSD DAC; **`--unwrap-dop`** runs `dop_decode` and pushes native DSD bytes through the existing `SND_PCM_FORMAT_DSD_U*` repack path for DACs that prefer native DSD over DoP-as-PCM.
+MTU/ptime guidance: DXD and DSD256-DoP stereo fit at 250 µs ptime (≤1059 B/packet); DSD512-DoP stereo requires 125 µs (1059 B); multichannel DXD routes through the M10 multi-stream split.
+DSD512-over-DoP at 1411200 Hz L24 is **out of AES67/Ravenna spec** (Merging gear caps at DSD256); shipped for non-Merging gear that handles 1.4112 MHz L24 carriers, gated only by the runtime MTU/ptime checks.
+
+**Documented constraints (post-Phase-E):**
 - AES67 channel counts typically cap at 8 per stream; higher counts split across multiple substreams via RFC 5888 `a=group:LS` SDP bundling (M10).
 - L16 payload is wire-format-ready (`rtp_swap16_inplace` exists) but not yet plumbed as a `--format` option — s24 is AOEther's PCM lock.
+- DoP is the only DSD-over-RTP carriage AOEther emits. Vendor-specific native-DSD-over-RTP framings (e.g. AM824 DSD subtypes) are not implemented; not standard on consumer Ravenna gear.
+- DSD512-DoP is supported but out-of-spec; passes only the runtime MTU check, not any standards conformance check. Document the specific gear it works against in `docs/recipe-merging.md`.
 
 **Key risks:**
 - AES67 has enough ambiguity in practice that interop edge cases are expected. Approach: start with `aes67-linux-daemon` as a known-good reference, then expand to commercial gear with iteration.

--- a/docs/recipe-aes67.md
+++ b/docs/recipe-aes67.md
@@ -180,6 +180,6 @@ Substitute your talker's host IP for `192.168.1.100`. For the low-latency profil
 - No payload-type negotiation — talker emits PT=96 unconditionally, receiver accepts any PT. Controllers negotiate PT through SDP in practice, so this rarely matters.
 - L16 encoding path exists in the common module but isn't exposed as a `--format` option yet.
 - 44.1 kHz / 88.2 kHz / 176.4 kHz work at the wire level but AES67 deployments overwhelmingly use 48 kHz / 96 kHz / 192 kHz.
-- `--transport rtp --format dsd*` is rejected; AES67 is PCM-only. DSD streams remain on Modes 1 / 3.
+- **DXD (352.8 / 384 kHz) and DSD-via-DoP** ship in M9 Phase E for full Ravenna interop. The talker/receiver still target the AES67 baseline (48 / 96 / 192 kHz PCM); for DXD or DSD with Merging-class gear see [`recipe-merging.md`](recipe-merging.md). Standard AES67 listeners (Neumann, Genelec, Dante) cap at 96 kHz and don't consume DXD or DoP — point those at the baseline rates.
 - Multichannel beyond stereo works but AES67 conventions cap per-stream channel count at 8; higher counts should be split into multiple sessions.
 - `--ptp` re-reads gmid via `pmc` every 30 s (not on every BMCA change). In the worst case a fresh master takes ≤30 s to propagate into SDP. If you need tighter tracking, reduce `SAP_ANNOUNCE_INTERVAL_S`.

--- a/docs/recipe-merging.md
+++ b/docs/recipe-merging.md
@@ -1,0 +1,202 @@
+# Merging Ravenna interop recipe (DXD + DoP)
+
+This recipe walks through full Ravenna interop with **Merging Technologies** gear (Hapi MkII, NADAC, Anubis, Horus) end-to-end on AOEther's `--transport rtp` path.
+M9 Phase A–C provided the AES67 baseline (PCM 48–192 kHz with SDP / SAP / PTPv2); Phase E adds **DXD** (352.8 / 384 kHz PCM) and **DoP** (DSD64 / 128 / 256 wrapped in L24 PCM) so the same path covers Merging's full feature set.
+
+For the AES67 baseline (Neumann KH AES67, Genelec SAM via Dante-AES67, Dutch & Dutch 8c) see [`recipe-aes67.md`](recipe-aes67.md).
+For the AVB/Milan path (L-Acoustics Creations, Mac CoreAudio sources) see [`recipe-milan.md`](recipe-milan.md).
+The architecture rationale for keeping both first-class is [`atmos-network-choice.md`](atmos-network-choice.md).
+
+## What works
+
+| Source | Wire format | Carrier rate | Merging support | AOEther flags |
+|---|---|---|---|---|
+| PCM 48 kHz | L24 RTP | 48000 Hz | Yes | `--format pcm --rate 48000` |
+| PCM 96 kHz | L24 RTP | 96000 Hz | Yes | `--format pcm --rate 96000` |
+| **DXD** 352.8 kHz | L24 RTP | 352800 Hz | Yes | `--format pcm --rate 352800 --ptime 250` |
+| **DXD** 384 kHz | L24 RTP | 384000 Hz | Yes | `--format pcm --rate 384000 --ptime 250` |
+| **DSD64-DoP** | L24 RTP | 176400 Hz | Yes | `--format dsd64 --ptime 250` |
+| **DSD128-DoP** | L24 RTP | 352800 Hz | Yes | `--format dsd128 --ptime 250` |
+| **DSD256-DoP** | L24 RTP | 705600 Hz | Yes (Merging cap) | `--format dsd256 --ptime 250` |
+| DSD512-DoP | L24 RTP | 1411200 Hz | **No** | `--format dsd512 --ptime 125` (out of spec) |
+
+Merging gear caps at DSD256 over DoP — that's the Ravenna spec ceiling.
+DSD512-DoP is supported by AOEther for non-Merging gear that handles 1.4112 MHz L24 carriers; it is explicitly out of AES67 / Ravenna spec.
+
+## Hardware setup
+
+Two-segment example: AOEther talker on Linux, Merging Hapi MkII as the listener, M4250 switch in **Dante / AES67 profile**.
+
+```
++----------------+      M4250         +-----------------+      analog
+| AOEther talker |----------------->  | Merging Hapi    |--------------->
+| (Linux + ptp4l)|   1 GbE / PTPv2    | MkII (Ravenna)  |    XLR / TRS
++----------------+                    +-----------------+
+
+PTPv2 grandmaster: typically the M4250's BC, or a dedicated Mellanox / Linux+I210 GM.
+See docs/ptp-setup.md for the daemon recipe.
+```
+
+Reverse direction works the same way: Merging gear as RTP talker, AOEther receiver into a USB DSD DAC.
+The two cases are symmetric in M9 Phase E.
+
+## Talker → Merging (DXD)
+
+```sh
+sudo ./build/talker \
+  --iface eno1 \
+  --transport rtp \
+  --dest-ip 239.10.20.30 \
+  --rate 384000 \
+  --format pcm \
+  --channels 2 \
+  --ptime 250 \
+  --ptp \
+  --announce-sap \
+  --session-name "AOEther DXD"
+```
+
+The `--ptime 250` is required at DXD: 1 ms ptime at 384 kHz × 2 ch × L24 = 2304 B/packet which exceeds 1500 B MTU.
+Merging gear accepts both 1 ms and 250 µs ptime.
+
+In Merging's ANEMAN, the announced session appears under "Sources".
+Drag it onto the Hapi MkII's input.
+PTP must converge first — if the talker's `--ptp` is on but the Hapi shows "PTP not synced", check that both are in the same PTP domain (`--ptp-domain N` on the talker; ANEMAN exposes the domain in the device properties).
+
+## Talker → Merging (DSD via DoP)
+
+```sh
+sudo ./build/talker \
+  --iface eno1 \
+  --transport rtp \
+  --dest-ip 239.10.20.30 \
+  --format dsd64 \
+  --source dsf --file album.dsf \
+  --channels 2 \
+  --ptime 250 \
+  --ptp \
+  --announce-sap \
+  --session-name "AOEther DSD64-DoP"
+```
+
+The talker reads native DSD bytes from the DSF file, runs the DoP encoder (`common/dop.c`), and emits L24 PCM at the carrier rate (176.4 kHz for DSD64).
+SDP advertises `L24/176400/2` — DoP is not signaled at the SDP layer, the Hapi detects it from the marker pattern in the L24 stream's MSB.
+
+For DSD256:
+
+```sh
+sudo ./build/talker ... --format dsd256 --ptime 250 ...
+```
+
+This emits L24 at 705.6 kHz.
+At 705.6 kHz × 2 ch × 3 = 4234 B/ms, so 250 µs ptime (1059 B/packet) is required.
+
+## Talker → Merging (multichannel DXD)
+
+For 7.1.6 (14 ch) DXD content, M10's multi-stream split applies — DXD is just PCM at a high rate, the bundling logic is the same as the M10 baseline.
+
+```sh
+sudo ./build/talker \
+  --iface eno1 \
+  --transport rtp \
+  --dest-ip 239.10.20.30 \
+  --rate 384000 \
+  --format pcm \
+  --channels 14 \
+  --channels-per-stream 8 \
+  --ptime 125 \
+  --ptp \
+  --announce-sap
+```
+
+Two substreams are emitted: 8 ch at `239.10.20.30` and 6 ch at `239.10.20.31`.
+SDP carries one bundled session with `a=group:LS 1 2`.
+Merging gear handles bundled multi-`m=` SDPs natively in ANEMAN; both substreams arrive sample-aligned.
+
+## Merging → AOEther (passthrough to DoP-capable USB DAC)
+
+The default receiver path treats incoming DoP-encoded RTP as plain L24 PCM and writes it to ALSA at the carrier rate.
+Any DoP-capable USB DSD DAC (Topping, Holo Audio, RME, Merging NADAC, Exasound, etc.) sees the marker pattern and switches to DSD internally.
+
+Subscribe to the Merging output in ANEMAN, point it at AOEther's multicast group, then on the AOEther receiver host:
+
+```sh
+sudo ./build/receiver \
+  --iface eth0 \
+  --dac hw:CARD=DAC,DEV=0 \
+  --transport rtp \
+  --group 239.10.20.40 \
+  --port 5004 \
+  --format dsd64 \
+  --channels 2
+```
+
+The receiver opens ALSA as `SND_PCM_FORMAT_S24_3LE` at 176400 Hz; the DAC receives the L24 stream, sees DoP markers, and outputs DSD audio.
+No `--alsa-format` override is needed — the passthrough path forces `pcm_s24_3le` regardless of `--format`.
+
+## Merging → AOEther (native DSD output via `--unwrap-dop`)
+
+For DACs that prefer native DSD over DoP-as-PCM (some snd_usb_audio quirk-tables only enable DSD via `SND_PCM_FORMAT_DSD_U*`), pass `--unwrap-dop` and an appropriate `--alsa-format`:
+
+```sh
+sudo ./build/receiver \
+  --iface eth0 \
+  --dac hw:CARD=DAC,DEV=0 \
+  --transport rtp \
+  --group 239.10.20.40 \
+  --format dsd64 \
+  --channels 2 \
+  --unwrap-dop \
+  --alsa-format dsd_u16_be
+```
+
+The receiver runs the DoP decoder (`dop_decode`), recovers native DSD bytes, and feeds them through the existing DSD-to-ALSA repack.
+ALSA opens at the matching DSD rate (176400 Hz × 2 bytes/frame for DSD_U16_BE = matches the DSD64 byte rate).
+
+For DSD256 the same flag pattern works:
+
+```sh
+... --format dsd256 --unwrap-dop --alsa-format dsd_u32_be
+```
+
+`SND_PCM_FORMAT_DSD_U8`, `DSD_U16_LE`, `DSD_U16_BE`, `DSD_U32_LE`, `DSD_U32_BE` are all valid; pick what your DAC's `snd_usb_audio` quirk exposes.
+
+## PTP setup notes
+
+Merging gear runs PTPv2 default profile (not gPTP / 802.1AS), in domain 0 by default.
+Configure `ptp4l` on the AOEther talker to match — see [`ptp-setup.md`](ptp-setup.md):
+
+```sh
+ptp4l -i eno1 -f /etc/linuxptp/default.cfg -m
+phc2sys -s eno1 -O 0 -m
+```
+
+The M4250 in Dante/AES67 profile boundaries PTP cleanly; in mixed deployments where you also have Milan gear in another VLAN, keep them separated — gPTP and PTPv2 default are profile-incompatible at the switch.
+
+## DSD512 (out of spec)
+
+DSD512-over-DoP runs L24 at 1.4112 MHz which is beyond AES67 / Ravenna's defined rate set.
+Merging gear refuses these sessions (and rightly so).
+Some non-Merging gear handles it — for example specific ESS-based USB DACs paired with a custom Linux talker / receiver pair.
+
+```sh
+sudo ./build/talker --transport rtp --format dsd512 --ptime 125 ...
+```
+
+Document any specific DAC you've validated against here.
+At 1411.2 kHz × 2 ch × 3 = 8467 B/ms; 250 µs (2117 B) still doesn't fit, so 125 µs ptime is mandatory.
+
+## Verification checklist
+
+- [ ] Talker `--sdp-only` at the chosen rate prints the expected `L24/<carrier>/<channels>` rtpmap.
+- [ ] `tcpdump -i eno1 udp port 5004` captures show the chosen ptime cadence (250 µs = 4000 pps; 125 µs = 8000 pps).
+- [ ] Wireshark on a captured DoP stream shows `0xFA` / `0x05` alternating in the most-significant byte of every 24-bit sample, identical across channels within a frame.
+- [ ] PTP converges on both ends (`pmc -u -b 0 'GET CURRENT_DATA_SET'` shows the same grandmaster).
+- [ ] Merging device subscribes successfully via ANEMAN, no audio dropout under sustained playback (≥ 1 hour soak).
+- [ ] On the receiver passthrough path, `aplay -l` shows the DAC at the carrier rate; on `--unwrap-dop`, `aplay -l` shows the DSD format the DAC's quirk exposes.
+
+## Out of scope
+
+- **AVDECC / Milan control plane** — Merging uses ANEMAN over RTSP/HTTP for control, not AVDECC. AOEther's M7 AVDECC support is for Milan listeners; it has no effect on Ravenna interop.
+- **Multichannel DSD via DoP** — supported in principle (the encoder is rate- and channel-count-general), but no consumer Ravenna gear consumes multichannel DSD streams. Multichannel DSD remains on Modes 1/3 with native-DSD format codes (`0x30..0x35`) into a single multichannel DSD DAC; see [`recipe-dsd.md`](recipe-dsd.md).
+- **DSD1024+** — DoP carrier would need ≥ 2.8224 MHz L24, no consumer endpoint or transport supports it.

--- a/docs/wire-format.md
+++ b/docs/wire-format.md
@@ -353,9 +353,45 @@ SAP discovery (`--announce-sap` / `--list-sap`) follows the same family: an IPv4
 
 ### What is not in Mode 4 today
 
-- **SDP / SAP** — M9 Phase B. Without SDP, the talker and receiver must agree on format / channels / rate / destination out of band. No dynamic payload-type negotiation.
-- **PTPv2 timestamp discipline** — M9 Phase C. The RTP timestamp advances from a local monotonic clock; it is not PTP-locked. Strict AES67 listeners may tolerate this or may not, depending on their sync policy.
 - **Mode C clock feedback** — disabled entirely under `--transport rtp`. AES67 expects PTP, not UAC2-style feedback. Receivers do not emit 0x88B6 frames when running in RTP mode.
+
+### DXD and DSD-over-DoP (M9 Phase E)
+
+Mode 4 carries **DXD** PCM (352.8 / 384 kHz, 24-bit) on the same L24 wire format as the AES67-baseline 48/96 kHz path — only the rate changes. SDP advertises `L24/352800/<channels>` or `L24/384000/<channels>`; receivers that don't support those rates in their decoder will reject the session, those that do play it as PCM.
+
+**DSD over Mode 4** rides as DoP-encoded L24 PCM at the carrier rate per [DoP v1.1](https://dsd-guide.com/sites/default/files/white-papers/DoP_open_Standard_1v1.pdf). Each L24 sample carries one DoP frame:
+
+```
+ byte 0 (MSB)  byte 1        byte 2 (LSB)
++------------+--------------+--------------+
+| marker     | DSD bits 0-7 | DSD bits 8-15|
+| 0xFA / 0x05|              |              |
++------------+--------------+--------------+
+```
+
+The marker alternates per frame across **all** channels of a given frame: frame F uses marker M, frame F+1 uses the other marker, and so on. AOEther emits `0xFA` on even frames and `0x05` on odd; listeners detect either polarity and the alternation rather than a fixed starting phase.
+
+The L24 carrier rate is the DSD bit rate divided by 16 (i.e. DSD byte rate / 2), since each L24 frame carries 16 DSD bits per channel:
+
+| DSD format | DSD bit rate | DSD byte rate | DoP carrier (L24) | Notes |
+|---|---|---|---|---|
+| DSD64 | 2.8224 MHz | 352800 Hz | 176400 Hz | Standard Ravenna |
+| DSD128 | 5.6448 MHz | 705600 Hz | 352800 Hz | Standard Ravenna; same rate as DXD |
+| DSD256 | 11.2896 MHz | 1411200 Hz | 705600 Hz | Merging Ravenna max |
+| DSD512 | 22.5792 MHz | 2822400 Hz | 1411200 Hz | **Out of AES67/Ravenna spec**; supported for non-Merging gear |
+
+DoP is **content-level**, not signaled in SDP. The talker advertises plain L24 at the carrier rate; the listener detects DoP from the marker pattern in the high byte of each sample. No new SDP attributes are introduced.
+
+**DSD byte layout** within DoP frames matches AOEther's AOE wire DSD layout (`byte_i * channels + c`, MSB-first within each byte). For each L24 frame `f`, the encoder reads two DSD-byte rows (`byte_i = 2f` and `byte_i = 2f+1`) for every channel and packs them under the marker. The decoder reverses the operation. This layout choice means the DoP encoder/decoder in `common/dop.{h,c}` can drive Modes 1/3 in addition to Mode 4 if those paths are later activated; the shared DSD I/O contract is the AOE wire layout.
+
+**Receiver output paths** for DoP-carrying Mode 4 streams:
+
+- **Passthrough (default)**: write the byte-swapped L24 stream to ALSA as `SND_PCM_FORMAT_S24_3LE` at the carrier rate. Any DoP-capable USB DSD DAC sees the marker pattern in the most-significant byte and switches to DSD internally.
+- **`--unwrap-dop`**: run the DoP decoder, recover native DSD bytes (AOE-wire layout), and feed the existing `SND_PCM_FORMAT_DSD_U*` ALSA repack. For DACs that prefer native DSD over DoP-as-PCM.
+
+**MTU and ptime** at high carrier rates: 1 ms ptime exceeds 1500-byte MTU above 192 kHz stereo. Use `--ptime 250` for DXD / DSD128-DoP / DSD256-DoP stereo (≤1059 B/packet), `--ptime 125` for DSD512-DoP stereo (1059 B), or rely on the M10 multi-stream split for multichannel DXD. The talker's startup MTU check rejects configs that exceed 1500 B at the chosen ptime.
+
+**Format codes 0x20..0x23** in the AoE-header table above are reserved for DoP-in-AOE-modes (Modes 1/3) and are not currently emitted or accepted by the talker / receiver. The Mode 4 DoP path documented here uses standard L24 PCM payload (no AOE-format-code field involved); only the L24 sample content is special.
 
 ### Multi-stream SDP bundling (M10)
 

--- a/receiver/Makefile
+++ b/receiver/Makefile
@@ -9,6 +9,7 @@ SRCS      := \
     src/receiver.c \
     ../common/packet.c \
     ../common/avtp.c \
+    ../common/dop.c \
     ../common/rtp.c \
     ../common/sdp.c \
     ../common/sap.c \
@@ -44,7 +45,7 @@ endif
 .PHONY: all clean
 all: $(BUILD)/receiver
 
-$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h ../common/rtp.h ../common/sdp.h ../common/sap.h ../common/mdns.h ../common/avdecc.h | $(BUILD)
+$(BUILD)/receiver: $(SRCS) ../common/packet.h ../common/avtp.h ../common/dop.h ../common/rtp.h ../common/sdp.h ../common/sap.h ../common/mdns.h ../common/avdecc.h | $(BUILD)
 	$(LINK) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/receiver/src/receiver.c
+++ b/receiver/src/receiver.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 #include "avdecc.h"
 #include "avtp.h"
+#include "dop.h"
 #include "mdns.h"
 #include "packet.h"
 #include "rtp.h"
@@ -70,6 +71,13 @@ static int rate_supported(int hz)
     case 44100: case 48000:
     case 88200: case 96000:
     case 176400: case 192000:
+        return 1;
+    /* M9 Phase E — DXD PCM (352.8/384) and DoP carrier rates for full
+     * Ravenna interop on the RTP path. 705.6 kHz is the DSD256-DoP
+     * carrier (Merging cap); 1411.2 kHz is the DSD512-DoP carrier (out
+     * of AES67/Ravenna spec; supported for non-Merging gear). */
+    case 352800: case 384000:
+    case 705600: case 1411200:
         return 1;
     default:
         return 0;
@@ -292,7 +300,16 @@ static void usage(const char *prog)
         "                       the receiver handles the transpose + endian conversion.\n"
         "  --channels N         stream channel count (1..64, default %d)\n"
         "  --rate HZ            PCM only: 44100|48000|88200|96000|176400|192000\n"
+        "                       | 352800|384000 (DXD, --transport rtp, M9 Phase E)\n"
+        "                       | 705600 (DSD256-DoP carrier) | 1411200 (DSD512-DoP,\n"
+        "                       out of AES67 spec)\n"
         "                       (default %d; ignored for DSD — rate is implied by --format)\n"
+        "  --unwrap-dop         under --transport rtp + --format dsd*, decode the\n"
+        "                       incoming DoP-encoded L24 stream back to native DSD\n"
+        "                       and write SND_PCM_FORMAT_DSD_U* to ALSA. Default is\n"
+        "                       passthrough — write L24 to ALSA as PCM_S24_3LE and\n"
+        "                       let the DoP-capable USB DAC handle the marker pattern.\n"
+        "                       Use this for DACs that prefer native DSD over DoP-as-PCM.\n"
         "  --latency-us N       ALSA period latency hint (default %d)\n"
         "  --no-feedback        do not emit Mode C FEEDBACK frames (diagnostic)\n"
         "  --announce           publish this receiver via mDNS-SD (_aoether._udp)\n"
@@ -366,6 +383,7 @@ int main(int argc, char **argv)
     int plc_enabled = 1;
     int plc_hold_ms = PLC_DEFAULT_HOLD_MS;
     int plc_ramp_ms = PLC_DEFAULT_RAMP_MS;
+    int unwrap_dop = 0;
 
     static const struct option opts[] = {
         { "iface",       required_argument, 0, 'i' },
@@ -385,6 +403,7 @@ int main(int argc, char **argv)
         { "list-sap",    optional_argument, 0, 1002 },
         { "sdp",         required_argument, 0, 1003 },
         { "plc",         required_argument, 0, 1004 },
+        { "unwrap-dop",  no_argument,       0, 1005 },
         { "help",        no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
@@ -425,6 +444,7 @@ int main(int argc, char **argv)
                 return 2;
             }
             break;
+        case 1005: unwrap_dop = 1; break;
         case 'h': usage(argv[0]); return 0;
         default:  usage(argv[0]); return 2;
         }
@@ -729,10 +749,35 @@ int main(int argc, char **argv)
         fprintf(stderr, "receiver: AVTP AAF does not carry DSD; use --transport l2 or ip\n");
         return 2;
     }
-    if (transport == TRANSPORT_RTP && fmt.is_dsd) {
-        fprintf(stderr, "receiver: AES67 RTP is PCM-only; use --transport l2 or ip with --format dsd*\n");
+    /* M9 Phase E — full Ravenna interop. Native DSD over RTP is carried
+     * as DoP-encoded L24 PCM at the carrier rate (DSD bit rate / 16).
+     * Two output paths:
+     *
+     *   1. Default (passthrough): write the BE-L24 stream to ALSA as
+     *      PCM_S24_3LE at the carrier rate. The DAC firmware sees the
+     *      DoP marker pattern (0xFA / 0x05) in the most significant
+     *      byte of each sample and switches to DSD internally. Works
+     *      with any DoP-capable USB DSD DAC (most modern ones do).
+     *
+     *   2. --unwrap-dop: dop_decode the L24 stream back to native DSD
+     *      bytes, channel-interleaved at byte granularity (matching
+     *      AOE's wire DSD layout), and run the existing DSD-to-ALSA
+     *      repack. For DACs that prefer SND_PCM_FORMAT_DSD_U* over
+     *      DoP-as-PCM. */
+    const int  dop_active =
+        (transport == TRANSPORT_RTP && fmt.is_dsd);
+    const uint32_t dop_carrier_hz =
+        dop_active ? dop_carrier_rate_for_dsd((uint32_t)rate_hz) : 0u;
+    if (dop_active && dop_carrier_hz == 0u) {
+        fprintf(stderr, "receiver: --format %s has no DoP carrier rate "
+                        "(internal table miss)\n", fmt.name);
         return 2;
     }
+    /* Wire-side rate seen on the RTP/L24 packets. Under DoP this is the
+     * carrier (DSD byte rate / 2); otherwise rate_hz is already the
+     * wire rate. */
+    const int wire_rate_hz =
+        dop_active ? (int)dop_carrier_hz : rate_hz;
 
     /* AVTP AAF only carries the standard NSR rates. */
     uint8_t avtp_nsr_code = 0;
@@ -746,19 +791,31 @@ int main(int argc, char **argv)
     const uint8_t expected_format_code = fmt.wire_code;
 
     /* Resolve ALSA variant. Default derives from --format; user can override
-     * for DSD when the DAC's snd_usb_audio quirk exposes only DSD_U16 / U32. */
+     * for DSD when the DAC's snd_usb_audio quirk exposes only DSD_U16 / U32.
+     * Under DoP passthrough, force PCM S24_3LE — the DAC sees the DoP
+     * marker in MSB and switches to DSD itself. */
     struct alsa_variant av;
-    if (!alsa_format_s) alsa_format_s = fmt.is_dsd ? "dsd_u8" : "pcm_s24_3le";
-    if (parse_alsa_variant(alsa_format_s, &av) < 0) {
-        fprintf(stderr, "receiver: unknown --alsa-format %s\n", alsa_format_s);
-        return 2;
-    }
-    if (av.is_dsd != fmt.is_dsd) {
-        fprintf(stderr,
-                "receiver: --alsa-format %s is %s but --format %s is %s\n",
-                alsa_format_s, av.is_dsd ? "DSD" : "PCM",
-                fmt.name, fmt.is_dsd ? "DSD" : "PCM");
-        return 2;
+    if (dop_active && !unwrap_dop) {
+        /* DoP passthrough: ALSA carries L24 PCM regardless of --format /
+         * --alsa-format. Ignore any user override here; the DAC handles
+         * the DSD interpretation downstream of ALSA. */
+        if (parse_alsa_variant("pcm_s24_3le", &av) < 0) {
+            fprintf(stderr, "receiver: internal: pcm_s24_3le lookup failed\n");
+            return 2;
+        }
+    } else {
+        if (!alsa_format_s) alsa_format_s = fmt.is_dsd ? "dsd_u8" : "pcm_s24_3le";
+        if (parse_alsa_variant(alsa_format_s, &av) < 0) {
+            fprintf(stderr, "receiver: unknown --alsa-format %s\n", alsa_format_s);
+            return 2;
+        }
+        if (av.is_dsd != fmt.is_dsd) {
+            fprintf(stderr,
+                    "receiver: --alsa-format %s is %s but --format %s is %s\n",
+                    alsa_format_s, av.is_dsd ? "DSD" : "PCM",
+                    fmt.name, fmt.is_dsd ? "DSD" : "PCM");
+            return 2;
+        }
     }
 
     /* Socket setup per transport. L2 keeps two raw AF_PACKET sockets (one
@@ -890,10 +947,15 @@ int main(int argc, char **argv)
     /* ALSA's "frame rate" differs from wire rate_hz for wider DSD formats:
      * each ALSA frame consumes av.n_bytes bytes per channel, so
      *   ALSA rate = (wire DSD byte rate per channel) / av.n_bytes.
-     * For PCM S24_3LE the two concepts coincide. */
-    const unsigned alsa_rate = fmt.is_dsd
-        ? (unsigned)rate_hz / (unsigned)av.n_bytes
-        : (unsigned)rate_hz;
+     * For PCM S24_3LE the two concepts coincide.
+     *
+     * DoP passthrough opens ALSA as PCM at the L24 carrier rate; the
+     * DAC sees DoP markers and runs DSD internally. */
+    const unsigned alsa_rate = (dop_active && !unwrap_dop)
+        ? (unsigned)wire_rate_hz
+        : (fmt.is_dsd
+            ? (unsigned)rate_hz / (unsigned)av.n_bytes
+            : (unsigned)rate_hz);
     err = snd_pcm_set_params(pcm,
                              av.alsa_format,
                              SND_PCM_ACCESS_RW_INTERLEAVED,
@@ -929,7 +991,9 @@ int main(int argc, char **argv)
     } else {
         const char *label = (transport == TRANSPORT_RTP) ? "rtp" : "ip";
         const char *wire_fmt =
-            (transport == TRANSPORT_RTP) ? "L24(BE)" : fmt.name;
+            dop_active
+                ? (unwrap_dop ? "L24(BE) DoP→DSD" : "L24(BE) DoP")
+                : ((transport == TRANSPORT_RTP) ? "L24(BE)" : fmt.name);
         fprintf(stderr,
                 "receiver: transport=%s family=%s %s port=%d%s%s\n"
                 "          iface=%s dac=%s fmt=%s alsa=%s ch=%d rate=%d alsa_rate=%u latency_us=%d feedback=%s%s\n",
@@ -1050,6 +1114,15 @@ int main(int argc, char **argv)
     uint8_t dsd_leftover[64 * 3];
     int     dsd_leftover_per_ch = 0;
 
+    /* M9 Phase E — DoP decoder state for --unwrap-dop (RTP + DSD).
+     * Persists across packets so marker parity stays in sync. */
+    struct dop_dec_state dop_dec_st = {0};
+    /* Scratch for DoP-decoded DSD bytes. Each L24 frame in produces 2
+     * DSD bytes per channel out, so worst case = (RX_BUF_BYTES / 3) * 2 ≈
+     * 2 * RX_BUF_BYTES / 3, comfortably under RX_BUF_BYTES. In-place decode
+     * is unsafe for ch >= 4 due to read/write aliasing within a frame. */
+    uint8_t dop_dsd_scratch[RX_BUF_BYTES];
+
     /* Mode C state. */
     uint64_t frames_written_total = 0;
     uint64_t last_consumed = 0;
@@ -1128,7 +1201,13 @@ int main(int argc, char **argv)
                  * PCM. No AoE header, no magic byte — the receiver decides
                  * this is RTP from --transport rtp. Format / channel
                  * validation comes from SDP in a future milestone;
-                 * for M9 Phase A we trust --rate / --channels / L24. */
+                 * for M9 Phase A we trust --rate / --channels / L24.
+                 *
+                 * M9 Phase E: under DoP (RTP + DSD format), the L24 stream
+                 * carries DSD content. With --unwrap-dop we run dop_decode
+                 * to recover native DSD bytes for ALSA's DSD_U* path; by
+                 * default we pass the L24 stream straight to ALSA as PCM
+                 * S24_3LE and let the DAC unwrap the DoP markers. */
                 if ((size_t)n < hdr_off + RTP_HDR_LEN) { dropped++; goto check_feedback; }
                 const struct rtp_hdr *rh =
                     (const struct rtp_hdr *)(buf + hdr_off);
@@ -1140,18 +1219,37 @@ int main(int argc, char **argv)
                 }
                 (void)rts; (void)rssrc;
                 payload_bytes = (size_t)n - hdr_off - RTP_HDR_LEN;
-                size_t per_sample = (size_t)channels * bytes_per_sample;
+                /* Wire is L24 (3 bytes per sample per channel) regardless
+                 * of whether the content is plain PCM or DoP-encoded DSD. */
+                const size_t wire_bps = 3u;
+                size_t per_sample = (size_t)channels * wire_bps;
                 if (per_sample == 0 || payload_bytes == 0 ||
                     payload_bytes % per_sample != 0) {
                     dropped++; goto check_feedback;
                 }
-                frames = payload_bytes / per_sample;
+                frames = payload_bytes / per_sample;  /* L24 frames per channel */
                 payload_p = buf + hdr_off + RTP_HDR_LEN;
-                /* L24 samples are big-endian; swap to ALSA LE in place. */
-                rtp_swap24_inplace(payload_p, frames * (size_t)channels);
-                /* RTP sequence is 16-bit; widen against last using the
-                 * AVTP-style 8-bit handling doesn't apply. Treat it as a
-                 * 32-bit value; the delta compare below handles wrap. */
+                if (dop_active && unwrap_dop) {
+                    /* Decode DoP into a scratch buffer (in-place is unsafe
+                     * for ch >= 4: within a frame, writes at offset 2f*ch+c
+                     * can clobber subsequent reads at offset 3f*ch+3c'+
+                     * {1,2}). The decoded DSD bytes use AOE wire layout
+                     * (byte_i * channels + c) so they feed directly into
+                     * the existing DSD-to-ALSA repack at the bottom of the
+                     * loop. */
+                    dop_decode(payload_p, dop_dsd_scratch, channels, frames,
+                               &dop_dec_st);
+                    payload_p = dop_dsd_scratch;
+                    /* Each L24 frame yields 2 DSD bytes per channel, so
+                     * the existing DSD path sees 2*frames "DSD-byte
+                     * frames" per channel. */
+                    frames = frames * 2u;
+                } else {
+                    /* L24 samples are big-endian; swap to ALSA LE in place.
+                     * Under DoP passthrough this preserves the marker in
+                     * the most-significant byte position the DAC expects. */
+                    rtp_swap24_inplace(payload_p, frames * (size_t)channels);
+                }
                 seq = (uint32_t)rseq;
             } else if (transport == TRANSPORT_AVTP) {
                 if ((size_t)n < hdr_off + AVTP_HDR_LEN) { dropped++; goto check_feedback; }

--- a/talker/Makefile
+++ b/talker/Makefile
@@ -15,6 +15,7 @@ SRCS      := \
     src/audio_source_dff.c \
     ../common/packet.c \
     ../common/avtp.c \
+    ../common/dop.c \
     ../common/rtp.c \
     ../common/sdp.c \
     ../common/sap.c \
@@ -36,7 +37,7 @@ endif
 .PHONY: all clean
 all: $(BUILD)/talker
 
-$(BUILD)/talker: $(SRCS) src/audio_source.h ../common/packet.h ../common/avtp.h ../common/rtp.h ../common/sdp.h ../common/sap.h ../common/ptp_pmc.h ../common/avdecc.h | $(BUILD)
+$(BUILD)/talker: $(SRCS) src/audio_source.h ../common/packet.h ../common/avtp.h ../common/dop.h ../common/rtp.h ../common/sdp.h ../common/sap.h ../common/ptp_pmc.h ../common/avdecc.h | $(BUILD)
 	$(LINK) $(CFLAGS) $(INCLUDES) $(SRCS) -o $@ $(LDLIBS)
 
 $(BUILD):

--- a/talker/src/talker.c
+++ b/talker/src/talker.c
@@ -2,6 +2,7 @@
 #include "audio_source.h"
 #include "avdecc.h"
 #include "avtp.h"
+#include "dop.h"
 #include "packet.h"
 #include "rtp.h"
 #include "sap.h"
@@ -189,6 +190,14 @@ static int rate_supported(int hz)
     case 44100: case 48000:
     case 88200: case 96000:
     case 176400: case 192000:
+        return 1;
+    /* M9 Phase E — DXD and DoP carrier rates for full Ravenna interop.
+     * 352800/384000 are DXD PCM; 352800/705600 also serve as DoP carriers
+     * for DSD128/DSD256 (Merging caps at DSD256). 1411200 is the DSD512
+     * DoP carrier — out of AES67/Ravenna spec, supported for non-Merging
+     * gear that handles it. */
+    case 352800: case 384000:
+    case 705600: case 1411200:
         return 1;
     default:
         return 0;
@@ -422,8 +431,17 @@ static void usage(const char *prog)
         "                               DoP remains deferred.\n"
         "                               AVTP transport carries pcm only.\n"
         "  --channels N                 channel count (1..64, default %d)\n"
-        "  --rate    HZ                 44100|48000|88200|96000|176400|192000 (default %d)\n"
-        "                               (ignored for native DSD — rate is implied by --format)\n"
+        "  --rate    HZ                 44100|48000|88200|96000|176400|192000\n"
+        "                               | 352800|384000 (DXD, --transport rtp, M9 Phase E)\n"
+        "                               | 705600 (DSD256-DoP carrier, advertised\n"
+        "                                 automatically when --format dsd256 + rtp)\n"
+        "                               | 1411200 (DSD512-DoP carrier, out of\n"
+        "                                 AES67 spec) (default %d)\n"
+        "                               (ignored for native DSD — rate is implied by --format;\n"
+        "                                under --transport rtp + dsd*, AOEther emits DoP-encoded\n"
+        "                                L24 at the corresponding carrier rate per the DoP v1.1\n"
+        "                                spec — Merging-style Ravenna interop, capped at DSD256\n"
+        "                                for Merging gear; DSD512 supported for non-Merging gear)\n"
         "\n"
         "PCM payload is s24le-3 (24-bit little-endian packed). Native DSD payload is\n"
         "raw DSD bits, MSB-first within each byte, interleaved by channel. Sources\n"
@@ -698,13 +716,33 @@ int main(int argc, char **argv)
         fprintf(stderr, "talker: AVTP AAF does not carry DSD; use --transport l2 or ip with --format dsd*\n");
         return 2;
     }
-    if (transport == TRANSPORT_RTP && fmt.is_dsd) {
-        fprintf(stderr, "talker: AES67 RTP is PCM-only; use --transport l2 or ip with --format dsd*\n");
+    /* M9 Phase E — full Ravenna interop. Native DSD over RTP rides as
+     * DoP-encoded L24 PCM at the carrier rate (DSD bit rate / 16, i.e.
+     * DSD byte rate / 2). The source still produces native DSD bytes;
+     * the egress loop runs dop_encode just before the RTP send. SDP,
+     * RTP timestamp clock, and the MTU/ptime budget all use the L24
+     * carrier rate (wire), not the DSD byte rate (source). */
+    const int  dop_active = (transport == TRANSPORT_RTP && fmt.is_dsd);
+    const uint32_t dop_carrier_hz =
+        dop_active ? dop_carrier_rate_for_dsd((uint32_t)rate_hz) : 0u;
+    if (dop_active && dop_carrier_hz == 0u) {
+        fprintf(stderr, "talker: --format %s has no DoP carrier rate "
+                        "(internal table miss)\n", fmt.name);
         return 2;
     }
     const uint8_t format_code = fmt.code;
     const int bytes_per_sample = fmt.bytes_per_sample;
     const int is_dsd = fmt.is_dsd;
+    /* Wire-side units. Under DoP, the source produces 2 DSD bytes per
+     * channel for every 1 L24 carrier frame (3 wire bytes). For the MTU
+     * and SDP math we want wire-frames × wire-bytes; "samples_per_*"
+     * remains source-units (DSD bytes per channel) so the existing
+     * fractional accumulator and source.read interface are unchanged. */
+    const int wire_rate_hz =
+        dop_active ? (int)dop_carrier_hz : rate_hz;
+    const int wire_bytes_per_sample =
+        dop_active ? 3 : bytes_per_sample;
+    (void)wire_bytes_per_sample;  /* MTU math uses dop_active branch directly */
 
     /* M9 Phase B + C — build one canonical SDP for the current stream.
      * Used by --sdp-only (print and exit) and --announce-sap (periodic
@@ -780,7 +818,7 @@ int main(int argc, char **argv)
         sdp.session_id    = (uint64_t)time(NULL);
         sdp.session_version = sdp.session_id;
         sdp.encoding      = SDP_ENC_L24;
-        sdp.sample_rate_hz = (uint32_t)rate_hz;
+        sdp.sample_rate_hz = (uint32_t)wire_rate_hz;
         sdp.channels      = (uint8_t)channels;
         sdp.payload_type  = RTP_DEFAULT_PT_L24;
         sdp.ptime_us      = (uint32_t)ptime_us;
@@ -802,8 +840,9 @@ int main(int argc, char **argv)
             char host[64] = "aoether";
             gethostname(host, sizeof host - 1);
             snprintf(sdp.session_name, SDP_MAX_SESSION_NAME,
-                     "%s %uch/%u", host,
-                     (unsigned)channels, (unsigned)rate_hz);
+                     "%s %uch/%u%s", host,
+                     (unsigned)channels, (unsigned)wire_rate_hz,
+                     dop_active ? " DoP" : "");
         }
         /* Defer sdp_build (and --sdp-only exit) to after substreams[] is
          * built, so the multi-stream bundle builder has per-substream
@@ -850,8 +889,19 @@ int main(int argc, char **argv)
     const double nominal_spm =
         (double)rate_hz * (double)packet_period_ns / 1e9;
     const int max_samples_per_microframe = (int)(nominal_spm + 0.5) + 4;
+    /* Source-units per microframe (DSD bytes/ch under DoP, samples/ch
+     * elsewhere) × channels × source-bytes-per-sample. The wire
+     * payload may be different — see wire_payload below. */
     const size_t max_microframe_payload =
         (size_t)max_samples_per_microframe * channels * bytes_per_sample;
+    /* Wire-side worst case for MTU checks. Under DoP, every 2 source
+     * units (DSD bytes) become 3 wire bytes (one L24 frame). The +1/2
+     * rounds up so an odd source-unit count still fits. */
+    const size_t max_microframe_payload_wire =
+        dop_active
+            ? ((size_t)((max_samples_per_microframe + 1) / 2)
+                 * (size_t)channels * 3u)
+            : max_microframe_payload;
 
     /* Per-fragment upper bound on payload_count: clamped by the u8 field
      * and by the worst-case per-fragment MTU budget. Fragmentation is an
@@ -886,9 +936,15 @@ int main(int argc, char **argv)
             check_ch = (channels < channels_per_stream)
                      ? channels : channels_per_stream;
         }
+        /* Under DoP the wire bytes per source unit are 3/2 (DSD-byte→L24);
+         * round up odd source-unit counts. Plain PCM/AVTP keep the
+         * source-unit accounting (1:1). */
         const size_t check_payload =
-            (size_t)max_samples_per_microframe
-            * (size_t)check_ch * (size_t)bytes_per_sample;
+            dop_active
+                ? ((size_t)((max_samples_per_microframe + 1) / 2)
+                     * (size_t)check_ch * 3u)
+                : ((size_t)max_samples_per_microframe
+                     * (size_t)check_ch * (size_t)bytes_per_sample);
         if ((transport == TRANSPORT_AVTP || transport == TRANSPORT_RTP) &&
             check_payload + proto_hdr_len > ETH_MTU_PAYLOAD) {
             const char *mode_name =
@@ -917,7 +973,8 @@ int main(int argc, char **argv)
      *     into `frame`. */
     const size_t max_frag_payload =
         (transport == TRANSPORT_AVTP || transport == TRANSPORT_RTP)
-            ? max_microframe_payload
+            ? (dop_active ? max_microframe_payload_wire
+                          : max_microframe_payload)
             : ((size_t)max_frag_pc * channels * bytes_per_sample);
     const size_t max_frame = sizeof(struct ether_header) + proto_hdr_len + max_frag_payload;
 
@@ -1240,6 +1297,19 @@ int main(int argc, char **argv)
 
     uint8_t *frame = calloc(1, max_frame);
     uint8_t *audio_buf = calloc(1, max_microframe_payload);
+    /* DoP scratch: holds one substream's DSD-byte slice between the
+     * substream gather and the dop_encode → payload step. Size = max
+     * source DSD bytes for any one substream = max_samples_per_microframe
+     * × channels (worst case: substream covers all channels). Only
+     * allocated under DoP. */
+    uint8_t *dop_scratch = NULL;
+    if (dop_active) {
+        dop_scratch = calloc(1, max_microframe_payload);
+        if (!dop_scratch) {
+            fprintf(stderr, "talker: out of memory allocating DoP scratch\n");
+            return 1;
+        }
+    }
     if (!frame || !audio_buf) {
         fprintf(stderr, "talker: out of memory allocating frame/audio buffers\n");
         return 1;
@@ -1322,6 +1392,7 @@ int main(int argc, char **argv)
         socklen_t dest_ss_len;
         uint32_t ssrc;
         uint16_t seq16;
+        struct dop_enc_state dop;  /* M9 Phase E: per-substream DoP parity */
     };
     struct rtp_substream substreams[MAX_RTP_SUBSTREAMS];
     int n_substreams = 0;
@@ -1509,7 +1580,7 @@ int main(int argc, char **argv)
                 m->dest_ip       = media_dest_bufs[s];
                 m->ttl           = dest_is_multicast ? 32 : 0;
                 m->encoding      = SDP_ENC_L24;
-                m->sample_rate_hz = (uint32_t)rate_hz;
+                m->sample_rate_hz = (uint32_t)wire_rate_hz;
                 m->channels      = (uint8_t)substreams[s].n_ch;
                 m->payload_type  = RTP_DEFAULT_PT_L24;
                 m->ptime_us      = (uint32_t)ptime_us;
@@ -1636,8 +1707,9 @@ int main(int argc, char **argv)
                 dest_family == AF_INET ? "v4" : "v6",
                 dest_is_multicast ? "multicast" : "unicast",
                 iface, ifindex,
-                transport == TRANSPORT_RTP ? "L24(BE)" : format_s,
-                channels, rate_hz,
+                dop_active ? "L24(BE) DoP" :
+                    (transport == TRANSPORT_RTP ? "L24(BE)" : format_s),
+                channels, dop_active ? wire_rate_hz : rate_hz,
                 pps, nominal_spm, max_frag_pc, nominal_K,
                 max_frame - sizeof(struct ether_header),
                 feedback_enabled_for_transport ? "on" : "off",
@@ -1881,6 +1953,21 @@ skip_feedback:
             if (pc < 1) pc = 1;
             if (pc > max_samples_per_microframe) pc = max_samples_per_microframe;
             sample_accum -= pc;
+            /* DoP packs 2 DSD bytes per channel into 1 L24 frame. Round
+             * pc down to even so each microframe carries whole L24
+             * frames; the spare DSD byte (if any) is carried forward
+             * via sample_accum. Ensure pc >= 2 so we always emit at
+             * least one L24 frame. */
+            if (dop_active) {
+                if (pc & 1) {
+                    pc -= 1;
+                    sample_accum += 1.0;
+                }
+                if (pc < 2) {
+                    pc = 2;
+                    sample_accum -= 1.0;
+                }
+            }
 
             /* Read one microframe of audio into the standalone audio_buf.
              * The source writes `pc` samples/bytes per channel, interleaved
@@ -1962,48 +2049,79 @@ skip_feedback:
                      * accurate multichannel. n_substreams == 1 is the
                      * single-stream fast path. Each substream carries its
                      * own SSRC and sequence counter; PTIME and payload type
-                     * match across the bundle. */
+                     * match across the bundle.
+                     *
+                     * M9 Phase E: under DoP, each substream gathers its
+                     * channel slice as DSD bytes, runs dop_encode into
+                     * the payload area (BE L24), and emits frag_pc/2
+                     * L24 frames. The DoP encoder produces network-byte-
+                     * order L24 directly, so rtp_swap24_inplace is
+                     * skipped on this path. */
+                    const int l24_frames =
+                        dop_active ? (frag_pc / 2) : frag_pc;
                     for (int s = 0; s < n_substreams && !g_stop; s++) {
                         struct rtp_substream *ss = &substreams[s];
                         const int ss_ch = ss->n_ch;
 
-                        /* Gather this substream's channel slice from the
-                         * interleaved audio_buf into the on-wire payload
-                         * area. Single-stream degenerates to a memcpy of
-                         * the whole microframe. */
-                        if (ss->first_ch == 0 && ss_ch == channels) {
-                            memcpy(payload, audio_buf,
-                                   (size_t)frag_pc * (size_t)ss_ch
-                                       * (size_t)bytes_per_sample);
-                        } else {
-                            const size_t ss_stride =
-                                (size_t)ss_ch * (size_t)bytes_per_sample;
-                            const size_t full_stride =
-                                (size_t)channels * (size_t)bytes_per_sample;
-                            const size_t ch_offset =
-                                (size_t)ss->first_ch * (size_t)bytes_per_sample;
-                            for (int samp = 0; samp < frag_pc; samp++) {
-                                memcpy(payload + (size_t)samp * ss_stride,
-                                       audio_buf
-                                           + (size_t)samp * full_stride
-                                           + ch_offset,
-                                       ss_stride);
+                        if (dop_active) {
+                            /* Gather DSD bytes for this substream's
+                             * channel range into dop_scratch. Source is
+                             * audio_buf with `frag_pc` DSD bytes per
+                             * channel, channels-interleaved at byte
+                             * granularity. */
+                            if (ss->first_ch == 0 && ss_ch == channels) {
+                                memcpy(dop_scratch, audio_buf,
+                                       (size_t)frag_pc * (size_t)ss_ch);
+                            } else {
+                                for (int samp = 0; samp < frag_pc; samp++) {
+                                    for (int c = 0; c < ss_ch; c++) {
+                                        dop_scratch[(size_t)samp * ss_ch + c] =
+                                            audio_buf[(size_t)samp * channels
+                                                      + ss->first_ch + c];
+                                    }
+                                }
                             }
+                            dop_encode(dop_scratch, payload, ss_ch,
+                                       (size_t)l24_frames, &ss->dop);
+                        } else {
+                            /* Plain PCM gather (M9/M10 fast path). */
+                            if (ss->first_ch == 0 && ss_ch == channels) {
+                                memcpy(payload, audio_buf,
+                                       (size_t)frag_pc * (size_t)ss_ch
+                                           * (size_t)bytes_per_sample);
+                            } else {
+                                const size_t ss_stride =
+                                    (size_t)ss_ch * (size_t)bytes_per_sample;
+                                const size_t full_stride =
+                                    (size_t)channels * (size_t)bytes_per_sample;
+                                const size_t ch_offset =
+                                    (size_t)ss->first_ch * (size_t)bytes_per_sample;
+                                for (int samp = 0; samp < frag_pc; samp++) {
+                                    memcpy(payload + (size_t)samp * ss_stride,
+                                           audio_buf
+                                               + (size_t)samp * full_stride
+                                               + ch_offset,
+                                           ss_stride);
+                                }
+                            }
+                            /* AES67 L24 samples are big-endian on the wire;
+                             * ALSA is LE. Swap in place, same as the AVTP
+                             * edge. */
+                            rtp_swap24_inplace(payload,
+                                               (size_t)frag_pc * (size_t)ss_ch);
                         }
-                        /* AES67 L24 samples are big-endian on the wire;
-                         * ALSA is LE. Swap in place, same as the AVTP
-                         * edge. */
-                        rtp_swap24_inplace(payload,
-                                           (size_t)frag_pc * (size_t)ss_ch);
                         rtp_hdr_build(rtp_hdr_p,
                                       RTP_DEFAULT_PT_L24,
                                       ss->seq16++,
                                       rtp_timestamp,
                                       ss->ssrc);
+                        const size_t ss_payload_bytes =
+                            dop_active
+                                ? ((size_t)l24_frames * (size_t)ss_ch * 3u)
+                                : ((size_t)frag_pc * (size_t)ss_ch
+                                       * (size_t)bytes_per_sample);
                         const size_t ss_frame_len =
-                            RTP_HDR_LEN
-                            + (size_t)frag_pc * (size_t)ss_ch
-                              * (size_t)bytes_per_sample;
+                            RTP_HDR_LEN + ss_payload_bytes;
                         ssize_t ss_sent = sendto(data_sock,
                                                  frame + tx_offset,
                                                  ss_frame_len, 0,
@@ -2019,8 +2137,10 @@ skip_feedback:
                             break;
                         }
                     }
-                    /* All substreams advance together. */
-                    rtp_timestamp += (uint32_t)frag_pc;
+                    /* All substreams advance together. RTP timestamp clock
+                     * is the L24 carrier rate under DoP, the source rate
+                     * otherwise. */
+                    rtp_timestamp += (uint32_t)l24_frames;
                     /* Multi-stream emission is self-contained; skip the
                      * shared single-packet sendto that follows the AOE /
                      * AVTP path. K is always 1 for RTP, so breaking the


### PR DESCRIPTION
## Summary

Closes #27. Lifts AOEther's M9 RTP path from AES67-strict to full Ravenna so it interops cleanly with Merging gear (Hapi MkII, NADAC, Anubis, Horus).

- **DXD** PCM at 352.8 / 384 kHz on the RTP path (was capped at 192 kHz).
- **DoP** carriage of native DSD per the DoP v1.1 spec — alternating `0xFA` / `0x05` marker in MSB, 16 DSD bits in the lower two bytes. Carrier rate = DSD bit rate / 16.
  - DSD64 → 176.4 kHz, DSD128 → 352.8, DSD256 → 705.6 (Merging cap)
  - DSD512 → 1.4112 MHz, out of AES67/Ravenna spec; supported for non-Merging gear that handles 1.4112 MHz L24.
- **Symmetric**: talker emits DoP from native DSD sources; receiver consumes it either as passthrough (default — DAC sees markers in MSB and switches to DSD) or `--unwrap-dop` (decode back to native DSD bytes for ALSA `DSD_U*` output).
- New `common/dop.{h,c}` (~150 LoC); DSD I/O uses AOE wire layout so the same module can drive Modes 1/3 if later activated.
- Updated docs: `design.md` M9 Phase E, `wire-format.md` DoP-in-RTP subsection, new `recipe-merging.md`, cross-link from `recipe-aes67.md`.

Round-trip tested locally on macOS for the DoP module (random DSD payloads, ch 2 / 4 / 8 / 16, including ch=4 odd-frame which exercises the in-place aliasing bug the scratch buffer avoids).

## Test plan

Linux validation pending — talker and receiver use Linux-only headers and weren't compiled in this PR. Reviewer should:

- [ ] `make` cleanly builds talker and receiver on Linux
- [ ] `talker --transport rtp --rate 384000 --format pcm --ptime 250 --sdp-only` prints SDP advertising `L24/384000/2`
- [ ] `talker --transport rtp --format dsd64 --source dsdsilence --sdp-only` prints SDP advertising `L24/176400/2`
- [ ] tcpdump capture of a DSD64 stream shows `0xFA` / `0x05` alternating in MSB across consecutive samples, identical across channels within a frame
- [ ] `aes67-linux-daemon` plays a DXD stream emitted by AOEther
- [ ] Symmetric loopback: AOEther talker DSD256-DoP → AOEther receiver passthrough → DoP-capable USB DSD DAC produces audible audio
- [ ] `--unwrap-dop --alsa-format dsd_u16_be` route works against a DSD-native DAC
- [ ] Merging hardware interop (hardware-blocked): Hapi MkII / NADAC / Anubis bidirectional at DSD64/128/256 and DXD 352.8/384

## MTU / ptime guidance

| Rate | Channels | 1 ms | 250 µs | 125 µs |
|---|---|---|---|---|
| 352.8 / 384 kHz stereo | 2 | over MTU | 530-576 B ✓ | 265-288 B ✓ |
| 705.6 kHz stereo (DSD256-DoP) | 2 | over MTU | 1059 B ✓ | 530 B ✓ |
| 1411.2 kHz stereo (DSD512-DoP) | 2 | over MTU | over MTU | 1059 B ✓ |

Talker rejects configs that exceed 1500 B at startup. DXD multichannel routes through M10 multi-stream split.
